### PR TITLE
Update usdc token address to goerli address

### DIFF
--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -146,7 +146,7 @@ The tokens are returned in alphabetical order by their symbol, so basically, the
     "symbol": "TUSD"
   },
   {
-    "address": "0xeb8f08a975ab53e34d8a0330e0d34de942c95926",
+    "address": "0xd35cceead182dcee0f148ebac9447da2c4d449c4",
     "decimals": 6,
     "name": "USD Coin",
     "symbol": "USDC"

--- a/docs/api/hardhat/getting-started.md
+++ b/docs/api/hardhat/getting-started.md
@@ -167,7 +167,7 @@ This section explains how to pay fees in `USDC` token as an example.
 1. After making sure that the wallet has some Görli `USDC` on L1, change the depositing code to the following:
 
 ```typescript
-const USDC_ADDRESS = "0xeb8f08a975ab53e34d8a0330e0d34de942c95926";
+const USDC_ADDRESS = "0xd35cceead182dcee0f148ebac9447da2c4d449c4";
 const USDC_DECIMALS = 6;
 
 const deploymentFee = await deployer.estimateDeployFee(artifact, [greeting], USDC_ADDRESS);
@@ -221,7 +221,7 @@ import * as ethers from "ethers";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
 
-const USDC_ADDRESS = "0xeb8f08a975ab53e34d8a0330e0d34de942c95926";
+const USDC_ADDRESS = "0xd35cceead182dcee0f148ebac9447da2c4d449c4";
 const USDC_DECIMALS = 6;
 
 // An example of a deploy script that will deploy and call a simple contract.

--- a/docs/api/js/accounts-l1-l2.md
+++ b/docs/api/js/accounts-l1-l2.md
@@ -44,7 +44,7 @@ const zkSyncProvider = new zksync.Provider("https://zksync2-testnet.zksync.dev/"
 const ethereumProvider = ethers.getDefaultProvider("goerli");
 const wallet = new zksync.Wallet(PRIVATE_KEY, zkSyncProvider, ethereumProvider);
 
-const USDC_ADDRESS = "0xeb8f08a975ab53e34d8a0330e0d34de942c95926";
+const USDC_ADDRESS = "0xd35cceead182dcee0f148ebac9447da2c4d449c4";
 const txHandle = await wallet.approveERC20(
   USDC_ADDRESS,
   "10000000" // 10.0 USDC
@@ -119,7 +119,7 @@ const zkSyncProvider = new zksync.Provider("https://zksync2-testnet.zksync.dev/"
 const ethereumProvider = ethers.getDefaultProvider("goerli");
 const wallet = new zksync.Wallet(PRIVATE_KEY, zkSyncProvider, ethereumProvider);
 
-const USDC_ADDRESS = "0xeb8f08a975ab53e34d8a0330e0d34de942c95926";
+const USDC_ADDRESS = "0xd35cceead182dcee0f148ebac9447da2c4d449c4";
 const usdcDepositHandle = await wallet.deposit({
   token: USDC_ADDRESS,
   amount: "10000000",

--- a/docs/api/js/accounts.md
+++ b/docs/api/js/accounts.md
@@ -157,7 +157,7 @@ const PRIVATE_KEY = "0xc8acb475bb76a4b8ee36ea4d0e516a755a17fad2e84427d5559b37b54
 
 const zkSyncProvider = new zksync.Provider("https://zksync2-testnet.zksync.dev");
 const ethereumProvider = ethers.getDefaultProvider("goerli");
-const USDC_ADDRESS = "0xeb8f08a975ab53e34d8a0330e0d34de942c95926";
+const USDC_ADDRESS = "0xd35cceead182dcee0f148ebac9447da2c4d449c4";
 const wallet = new Wallet(PRIVATE_KEY, zkSyncProvider);
 
 // Getting balance in USDC
@@ -191,7 +191,7 @@ const PRIVATE_KEY = "0xc8acb475bb76a4b8ee36ea4d0e516a755a17fad2e84427d5559b37b54
 
 const zkSyncProvider = new zksync.Provider("https://zksync2-testnet.zksync.dev");
 const ethereumProvider = ethers.getDefaultProvider("goerli");
-const USDC_ADDRESS = "0xeb8f08a975ab53e34d8a0330e0d34de942c95926";
+const USDC_ADDRESS = "0xd35cceead182dcee0f148ebac9447da2c4d449c4";
 const wallet = new Wallet(PRIVATE_KEY, zkSyncProvider);
 
 // Getting balance in USDC
@@ -225,7 +225,7 @@ import { ethers } from "ethers";
 const PRIVATE_KEY = "0xc8acb475bb76a4b8ee36ea4d0e516a755a17fad2e84427d5559b37b544d9ba5a";
 
 const zkSyncProvider = new zksync.Provider("https://zksync2-testnet.zksync.dev");
-const USDC_ADDRESS = "0xeb8f08a975ab53e34d8a0330e0d34de942c95926";
+const USDC_ADDRESS = "0xd35cceead182dcee0f148ebac9447da2c4d449c4";
 // Note that we don't need ethereum provider to get the nonce
 const wallet = new Wallet(PRIVATE_KEY, zkSyncProvider);
 
@@ -277,7 +277,7 @@ const wallet = new zksync.Wallet(PRIVATE_KEY, zkSyncProvider, ethereumProvider);
 
 const recipient = zksync.Wallet.createRandom();
 
-const USDC_ADDRESS = "0xeb8f08a975ab53e34d8a0330e0d34de942c95926";
+const USDC_ADDRESS = "0xd35cceead182dcee0f148ebac9447da2c4d449c4";
 // We transfer 0.01 ETH to the recipient and pay the fee in USDC
 const transferHandle = wallet.transfer({
   to: recipient.address,
@@ -424,7 +424,7 @@ const signer = provider.getSigner();
 
 const recipient = Wallet.createRandom();
 
-const USDC_ADDRESS = "0xeb8f08a975ab53e34d8a0330e0d34de942c95926";
+const USDC_ADDRESS = "0xd35cceead182dcee0f148ebac9447da2c4d449c4";
 // We transfer 0.01 ETH to the recipient and pay the fee in USDC
 const transferHandle = signer.transfer({
   to: recipient.address,

--- a/docs/api/js/features.md
+++ b/docs/api/js/features.md
@@ -34,23 +34,23 @@ In order to make the SDK as flexible as possible, the library uses the overrides
 
 Examples:
 
-Override to pay fees in the token with the address `0xeb8f08a975ab53e34d8a0330e0d34de942c95926`:
+Override to pay fees in the token with the address `0xd35cceead182dcee0f148ebac9447da2c4d449c4`:
 
 ```typescript
 {
   customData: {
-    feeToken: "0xeb8f08a975ab53e34d8a0330e0d34de942c95926";
+    feeToken: "0xd35cceead182dcee0f148ebac9447da2c4d449c4";
   }
 }
 ```
 
-Override to withdraw ETH and pay fees in the token with the address `0xeb8f08a975ab53e34d8a0330e0d34de942c95926`:
+Override to withdraw ETH and pay fees in the token with the address `0xd35cceead182dcee0f148ebac9447da2c4d449c4`:
 zzz
 
 ```typescript
 {
     customData: {
-        feeToken: "0xeb8f08a975ab53e34d8a0330e0d34de942c95926",
+        feeToken: "0xd35cceead182dcee0f148ebac9447da2c4d449c4",
         withdrawToken: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE"
     }
 }
@@ -78,7 +78,7 @@ If you want to call the method `setGreeting` of an ethers `Contract` object call
 const txHandle = greeter.setGreeting("some new greeting", {
   customData: {
     // Paying fee in USDC
-    feeToken: "0xeb8f08a975ab53e34d8a0330e0d34de942c95926",
+    feeToken: "0xd35cceead182dcee0f148ebac9447da2c4d449c4",
   },
 });
 ```

--- a/docs/api/js/getting-started.md
+++ b/docs/api/js/getting-started.md
@@ -108,7 +108,7 @@ const transfer = await syncWallet.transfer({
   to: syncWallet2.address,
   token: zksync.utils.ETH_ADDRESS,
   amount,
-  feeToken: "0xeb8f08a975ab53e34d8a0330e0d34de942c95926s", // USDC address
+  feeToken: "0xd35cceead182dcee0f148ebac9447da2c4d449c4s", // USDC address
 });
 ```
 

--- a/docs/api/js/providers.md
+++ b/docs/api/js/providers.md
@@ -69,7 +69,7 @@ async getBalance(address: Address, blockTag?: BlockTag, tokenAddress?: Address):
 import { Provider } from "zksync-web3";
 
 const provider = new Provider("https://zksync2-testnet.zksync.dev");
-const USDC_ADDRESS = "0xeb8f08a975ab53e34d8a0330e0d34de942c95926";
+const USDC_ADDRESS = "0xd35cceead182dcee0f148ebac9447da2c4d449c4";
 
 // Getting  USDC balance of account 0x0614BB23D91625E60c24AAD6a2E6e2c03461ebC5 at the latest processed block
 console.log(await provider.getBalance("0x0614BB23D91625E60c24AAD6a2E6e2c03461ebC5", "latest", USDC_ADDRESS));
@@ -146,7 +146,7 @@ async isTokenLiquid(token: Address): Promise<boolean>
 import { Provider } from "zksync-web3";
 const provider = new Provider("https://zksync2-testnet.zksync.dev");
 
-const USDC_ADDRESS = "0xeb8f08a975ab53e34d8a0330e0d34de942c95926";
+const USDC_ADDRESS = "0xd35cceead182dcee0f148ebac9447da2c4d449c4";
 console.log(await provider.isTokenLiquid(USDC_ADDRESS)); // Should return true
 ```
 
@@ -170,7 +170,7 @@ async getTokenPrice(token: Address): Promise<string>
 import { Provider } from "zksync-web3";
 const provider = new Provider("https://zksync2-testnet.zksync.dev");
 
-const USDC_ADDRESS = "0xeb8f08a975ab53e34d8a0330e0d34de942c95926";
+const USDC_ADDRESS = "0xd35cceead182dcee0f148ebac9447da2c4d449c4";
 console.log(await provider.getTokenPrice(USDC_ADDRESS));
 ``` -->
 

--- a/docs/dev/guide/hello-world.md
+++ b/docs/dev/guide/hello-world.md
@@ -137,7 +137,7 @@ This section is optional, and is used to learn how to pay for the deployment of 
 1. For example, to pay fees in the `USDC` token:
 
 ```typescript
-const USDC_ADDRESS = "0xeb8f08a975ab53e34d8a0330e0d34de942c95926";
+const USDC_ADDRESS = "0xd35cceead182dcee0f148ebac9447da2c4d449c4";
 const USDC_DECIMALS = 6;
 
 const deploymentFee = await deployer.estimateDeployFee(artifact, [greeting], USDC_ADDRESS);
@@ -191,7 +191,7 @@ import * as ethers from "ethers";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
 
-const USDC_ADDRESS = "0xeb8f08a975ab53e34d8a0330e0d34de942c95926";
+const USDC_ADDRESS = "0xd35cceead182dcee0f148ebac9447da2c4d449c4";
 const USDC_DECIMALS = 6;
 
 // An example of a deploy script that will deploy and call a simple contract.

--- a/docs/dev/guide/l1-l2.md
+++ b/docs/dev/guide/l1-l2.md
@@ -142,7 +142,7 @@ contract Example {
         // should be built in mind that deposits may require fee in the future.
         zksync.depositERC20{value: msg.value}(
             // The ERC20 token address to deposit.
-            0xeb8f08a975ab53e34d8a0330e0d34de942c95926s,
+            0xd35cceead182dcee0f148ebac9447da2c4d449c4s,
             // The amount to deposit
             1000000000,
             // The address of the recipient of the funds on L2.
@@ -250,7 +250,7 @@ contract Example {
 
         zksync.addToken{value: msg.value}(
             // The L1 address of the ERC20 token to add.
-            0xeb8f08a975ab53e34d8a0330e0d34de942c95926s,
+            0xd35cceead182dcee0f148ebac9447da2c4d449c4s,
             // The queue type
             Operations.QueueType.Deque,
             // The operation tree type


### PR DESCRIPTION
I noticed when going through the docs that the USDC address was still pointing to the [rinkeby version](https://rinkeby.etherscan.io/address/0xeb8f08a975ab53e34d8a0330e0d34de942c95926). This will update it everywhere found in the docs to the [goerli version](https://goerli.etherscan.io/address/0xd35cceead182dcee0f148ebac9447da2c4d449c4)