### PR TITLE
misc(config/zkSyncDeploy/ethNetwork): shows where RPC can be provided

### DIFF
--- a/docs/api/hardhat/compiling-libraries.md
+++ b/docs/api/hardhat/compiling-libraries.md
@@ -80,7 +80,7 @@ module.exports = {
   },
   zkSyncDeploy: {
     zkSyncNetwork: "https://zksync2-testnet.zksync.dev",
-    ethNetwork: "goerli", // Can also be RPC address of network (e.g. `https://goerli.infura.io/v3/<API_KEY>`)
+    ethNetwork: "goerli", // Can also be the RPC URL of the network (e.g. `https://goerli.infura.io/v3/<API_KEY>`)
   },
   solidity: {
     version: "0.8.11",

--- a/docs/api/hardhat/compiling-libraries.md
+++ b/docs/api/hardhat/compiling-libraries.md
@@ -80,7 +80,7 @@ module.exports = {
   },
   zkSyncDeploy: {
     zkSyncNetwork: "https://zksync2-testnet.zksync.dev",
-    ethNetwork: "goerli",
+    ethNetwork: "goerli", // Can also be RPC address of network (e.g. `https://goerli.infura.io/v3/<API_KEY>`)
   },
   solidity: {
     version: "0.8.11",

--- a/docs/api/hardhat/getting-started.md
+++ b/docs/api/hardhat/getting-started.md
@@ -53,7 +53,7 @@ module.exports = {
   },
   zkSyncDeploy: {
     zkSyncNetwork: "https://zksync2-testnet.zksync.dev",
-    ethNetwork: "goerli",
+    ethNetwork: "goerli", // Can also be RPC address of network (e.g. `https://goerli.infura.io/v3/<API_KEY>`)
   },
   solidity: {
     version: "0.8.11",

--- a/docs/api/hardhat/getting-started.md
+++ b/docs/api/hardhat/getting-started.md
@@ -53,7 +53,7 @@ module.exports = {
   },
   zkSyncDeploy: {
     zkSyncNetwork: "https://zksync2-testnet.zksync.dev",
-    ethNetwork: "goerli", // Can also be RPC address of network (e.g. `https://goerli.infura.io/v3/<API_KEY>`)
+    ethNetwork: "goerli", // Can also be the RPC URL of the network (e.g. `https://goerli.infura.io/v3/<API_KEY>`)
   },
   solidity: {
     version: "0.8.11",

--- a/docs/dev/guide/cross-chain-tutorial.md
+++ b/docs/dev/guide/cross-chain-tutorial.md
@@ -148,7 +148,7 @@ module.exports = {
   },
   zkSyncDeploy: {
     zkSyncNetwork: "https://zksync2-testnet.zksync.dev",
-    ethNetwork: "goerli",
+    ethNetwork: "goerli", // Can also be RPC address of network (e.g. `https://goerli.infura.io/v3/<API_KEY>`)
   },
   solidity: {
     version: "0.8.11",

--- a/docs/dev/guide/cross-chain-tutorial.md
+++ b/docs/dev/guide/cross-chain-tutorial.md
@@ -148,7 +148,7 @@ module.exports = {
   },
   zkSyncDeploy: {
     zkSyncNetwork: "https://zksync2-testnet.zksync.dev",
-    ethNetwork: "goerli", // Can also be RPC address of network (e.g. `https://goerli.infura.io/v3/<API_KEY>`)
+    ethNetwork: "goerli", // Can also be the RPC URL of the network (e.g. `https://goerli.infura.io/v3/<API_KEY>`)
   },
   solidity: {
     version: "0.8.11",

--- a/docs/dev/guide/hello-world.md
+++ b/docs/dev/guide/hello-world.md
@@ -43,7 +43,7 @@ module.exports = {
   },
   zkSyncDeploy: {
     zkSyncNetwork: "https://zksync2-testnet.zksync.dev",
-    ethNetwork: "goerli", // Can also be RPC address of network (e.g. `https://goerli.infura.io/v3/<API_KEY>`)
+    ethNetwork: "goerli", // Can also be the RPC URL of the network (e.g. `https://goerli.infura.io/v3/<API_KEY>`)
   },
   solidity: {
     version: "0.8.10",

--- a/docs/dev/guide/hello-world.md
+++ b/docs/dev/guide/hello-world.md
@@ -43,7 +43,7 @@ module.exports = {
   },
   zkSyncDeploy: {
     zkSyncNetwork: "https://zksync2-testnet.zksync.dev",
-    ethNetwork: "goerli",
+    ethNetwork: "goerli", // Can also be RPC address of network (e.g. `https://goerli.infura.io/v3/<API_KEY>`)
   },
   solidity: {
     version: "0.8.10",


### PR DESCRIPTION
Right now, if anyone uses the default setup shown in the tutorials within the documentation, they will be using a heavily throttled default API key:

![Screenshot 2022-02-23 at 15 21 51](https://user-images.githubusercontent.com/14224459/155327578-7ae164c2-9d0c-4179-a2ef-81d14eb33b81.png)

I don't believe it is clear or obvious how to avoid this, so I think adding these comments from this PR into the example code will make it much easier for developers to avoid running into this throttling (by pointing out where their own RPC address can be provided).