### PR TITLE
Minor fixes

### DIFF
--- a/docs/api/js/getting-started.md
+++ b/docs/api/js/getting-started.md
@@ -6,7 +6,7 @@ While most of the existing SDKs should work out of the box, deploying smart cont
 
 To provide easy access to all of the features of zkSync 2.0, the `zksync-web3` JavaScript SDK was created, which is made in a way that has an interface very similar to those of [ethers](https://docs.ethers.io/v5/). In fact, `ethers` is a peer dependency of our library and most of the objects exported by `zksync-web3` (e.g. `Wallet`, `Provider` etc.) inherit from the corresponding `ethers` objects and override only the fields that need to be changed.
 
-The library is made in such a way that after changing `ethers` with `zksync-web3` most client apps will work out of box. 
+The library is made in such a way that after replacing `ethers` with `zksync-web3` most client apps will work out of box. 
 
 ## Adding dependencies
 

--- a/docs/api/js/getting-started.md
+++ b/docs/api/js/getting-started.md
@@ -6,7 +6,7 @@ While most of the existing SDKs should work out of the box, deploying smart cont
 
 To provide easy access to all of the features of zkSync 2.0, the `zksync-web3` JavaScript SDK was created, which is made in a way that has an interface very similar to those of [ethers](https://docs.ethers.io/v5/). In fact, `ethers` is a peer dependency of our library and most of the objects exported by `zksync-web3` (e.g. `Wallet`, `Provider` etc.) inherit from the corresponding `ethers` objects and override only the fields that need to be changed.
 
-The library is made in such a way that changing `ethers` with `zksync-web3` for client-related me
+The library is made in such a way that after changing `ethers` with `zksync-web3` most client apps will work out of box. 
 
 ## Adding dependencies
 

--- a/docs/dev/testnet/known-issues.md
+++ b/docs/dev/testnet/known-issues.md
@@ -64,3 +64,11 @@ If you encounter such an error, please do the following:
 
 If you are running Windows you may get this error, as a result of incompatibility with our hardhat plugin.
 You can still compile the contract using Windows Subsystem for Linux (WSL 2).
+
+## Can not use CREATE/CREATE2 opcodes with raw bytecode
+
+zkSync does not support using CREATE/CREATE2 with raw bytecode. We highly recommend using the `new` operator to avoid any issues.
+
+## Hardhat's `console.log` does not work
+
+zkSync does not support Nomic Foundation's `console.log` contract. Due to different address derivation rules, even when deployed, the `console.log` library will likely have a different address from the one on Ethereum.

--- a/docs/dev/testnet/known-issues.md
+++ b/docs/dev/testnet/known-issues.md
@@ -71,4 +71,4 @@ zkSync does not support using CREATE/CREATE2 with raw bytecode. We highly recomm
 
 ## Hardhat's `console.log` does not work
 
-zkSync does not support Nomic Foundation's `console.log` contract. Due to different address derivation rules, even when deployed, the `console.log` library will likely have a different address from the one on Ethereum.
+zkSync does not support the Nomic Foundation's `console.log` contract. Due to different address derivation rules, even when deployed, the `console.log` library will likely have a different address from the one on Ethereum.


### PR DESCRIPTION
- [ ] Document that Hardhat's `console.log` does not work.
- [ ] Document that CREATE/CREATE2 opcodes can not be used with raw bytecode.
- [ ] Closes #55 