### PR TITLE
Add FoxWallet link

### DIFF
--- a/docs/dev/testnet/important-links.md
+++ b/docs/dev/testnet/important-links.md
@@ -2,7 +2,8 @@
 
 ### Faucet, bridge, wallet
 
-[zkSync 2.0 Portal](https://portal.zksync.io).
+- [zkSync 2.0 Portal](https://portal.zksync.io).
+- [FoxWallet](https://foxwallet.com/)
 
 ### Block explorer
 


### PR DESCRIPTION
zkSync 2.0 alpha testnet is natively supported in FoxWallet, here's the usage: https://hc.foxwallet.com/docs/ethereum-advance/zksync-v2-alpha-testnet