### PR TITLE
Update to L1 -> L2 communication contents

### DIFF
--- a/docs/dev/guide/l1-l2.md
+++ b/docs/dev/guide/l1-l2.md
@@ -1,14 +1,14 @@
 # L1 -> L2 communication
 
-This section describes the interface for interaction with zkSync from L1. It assumes that you are already familiar with the basic concepts of working with the priority queue. If you are new to this topic, you can read the conceptual introduction [here](../zksync-v2/l1-l2-interop.md#priority-queue). If you want to dive straight into the code, then you can read the cross-chain governance [tutorial](./cross-chain-tutorial.md).
+This section describes the interface for interaction with zkSync from L1. It assumes that you are already familiar with the basic concepts of working with the priority queue. You can read the conceptual introduction [here](../zksync-v2/l1-l2-interop.md#priority-queue). If you are new to this topic. You can read the cross-chain governance [tutorial](./cross-chain-tutorial.md) to dive straight into the code.
 
 ## Structure
 
-Besides the input parameters of the operations, all requests should contain the last parameter - the `_queueType`. These are the important parts of the censorship-resistant protocol called [priority queue](../zksync-v2/l1-l2-interop.md#priority-queue). For the current testnet phase, this value should be supplied as `0`, i.e. `QueueType.Deque`.
+Besides the input parameters of the operations, all requests should contain the last parameter - the `_queueType`. These are the important parts of the censorship-resistant protocol called [priority queue](../zksync-v2/l1-l2-interop.md#priority-queue). For the current testnet phase, you should supply this value as `0`, i.e., `QueueType.Deque`.
 
-To prevent users from requesting too many heavy operations from the operator, users must provide the fee to be paid to the zkSync operator in ETH. Each transaction has _base cost_ in gas and the _layer 2 tip_, which is equal to the basic cost of the requested transaction subtracted from the ETH value passed with the call.
+To prevent users from requesting too many heavy operations from the operator, users must provide the fee to be paid to the zkSync operator in ETH. Each transaction has _base cost_ in gas and the _layer 2 tip_, equal to the basic cost of the requested transaction subtracted from the ETH value passed with the call.
 
-Basic costs are defined in gas and not in ETH, so the actual amount of ether that the submission of the transaction will cost depends on the transaction gas price. Generally the flow for calling any of these methods should be the following:
+Basic costs are defined in gas and not ETH, so the amount of ether that the submission of the transaction will cost depends on the gas price. Generally, the flow for calling any of these methods should be the following:
 
 1. Fetch the gas price that you will use during the transaction call.
 2. Get the base cost for the transaction.
@@ -29,12 +29,12 @@ The `@matterlabs/zksync-contracts` package can be installed by running the follo
 yarn add -D @matterlabs/zksync-contracts
 ```
 
-In the examples below we assume that the interface is accessed via the `@matterlabs/zksync-contracts` npm package.
+The examples below assume that the interface is accessed via the `@matterlabs/zksync-contracts` npm package.
 
 ### Getting the base cost
 
 
-The following view function returns the amount of ETH that is needed to be supplied by the user to cover the base cost of the transaction.
+The following view function returns the amount of ETH needed to be supplied by the user to cover the base cost of the transaction.
 
 ```solidity
 function l2TransactionBaseCost(
@@ -53,7 +53,7 @@ function l2TransactionBaseCost(
 ### Interface
 
 
-The following function returns the canonical hash or the requested transaction, that can be used to track the execution of the transaction in L2.
+The following function returns the canonical hash or the requested transaction, that you can use to track the execution of the transaction in L2.
 
 ```solidity
 function requestL2Transaction(


### PR DESCRIPTION
Updated the contents on the L1 -> L2 communication page, and fixed grammar issues, and typos.