### PR TITLE
Update compiler tag

### DIFF
--- a/docs/api/hardhat/compiling-libraries.md
+++ b/docs/api/hardhat/compiling-libraries.md
@@ -62,7 +62,7 @@ require("@matterlabs/hardhat-zksync-solc");
 
 module.exports = {
   zksolc: {
-    version: "1.1.5",
+    version: "1.2.0",
     compilerSource: "docker",
     settings: {
       optimizer: {
@@ -70,7 +70,7 @@ module.exports = {
       },
       experimental: {
         dockerImage: "matterlabs/zksolc",
-        tag: "v1.1.5"
+        tag: "v1.2.0"
       },
       libraries: {
         "contracts/MiniMath.sol": {

--- a/docs/api/hardhat/getting-started.md
+++ b/docs/api/hardhat/getting-started.md
@@ -42,7 +42,7 @@ require("@matterlabs/hardhat-zksync-solc");
 
 module.exports = {
   zksolc: {
-    version: "1.1.5",
+    version: "1.2.0",
     compilerSource: "docker",
     settings: {
       optimizer: {
@@ -50,7 +50,7 @@ module.exports = {
       },
       experimental: {
         dockerImage: "matterlabs/zksolc",
-        tag: "v1.1.5"
+        tag: "v1.2.0"
       }
     },
   },

--- a/docs/dev/developer-guides/hello-world.md
+++ b/docs/dev/developer-guides/hello-world.md
@@ -38,7 +38,7 @@ require("@matterlabs/hardhat-zksync-solc");
 
 module.exports = {
   zksolc: {
-    version: "1.1.5",
+    version: "1.2.0",
     compilerSource: "docker",
     settings: {
       optimizer: {
@@ -46,7 +46,7 @@ module.exports = {
       },
       experimental: {
         dockerImage: "matterlabs/zksolc",
-        tag: "v1.1.5"
+        tag: "v1.2.0"
       },
     },
   },

--- a/docs/dev/tutorials/cross-chain-tutorial.md
+++ b/docs/dev/tutorials/cross-chain-tutorial.md
@@ -131,7 +131,7 @@ require("@matterlabs/hardhat-zksync-solc");
 
 module.exports = {
   zksolc: {
-    version: "1.1.5",
+    version: "1.2.0",
     compilerSource: "docker",
     settings: {
       optimizer: {
@@ -139,7 +139,7 @@ module.exports = {
       },
       experimental: {
         dockerImage: "matterlabs/zksolc",
-        tag: "v1.1.5"
+        tag: "v1.2.0"
       }
     },
   },
@@ -153,7 +153,7 @@ module.exports = {
     },
   },
   solidity: {
-    version: "0.8.11",
+    version: "0.8.16",
   },
 };
 ```


### PR DESCRIPTION
**Don't merge yet**

Only merge this when a docker image `matterlabs/zksolc:v1.2.0` is published.

This makes tutorials up to date with the updated testnet (regenesis expected Mon 10.10.2022).

Don't forget to publish the 0.11.0 `zksync-web3` as well.