### PR TITLE
Fixes account abstraction tutorial

### DIFF
--- a/docs/dev/tutorials/custom-aa-tutorial.md
+++ b/docs/dev/tutorials/custom-aa-tutorial.md
@@ -34,7 +34,7 @@ Since we are working with zkSync contracts, we also need to install the package 
 yarn add @matterlabs/zksync-contracts @openzeppelin/contracts @openzeppelin/contracts-upgradeable
 ```
 
-Also, create the `hardhat.config.ts` config file, `contracts` and `deploy` folders, like in the [Hello World](./hello-world.md) tutorial.
+Also, create the `hardhat.config.ts` config file, `contracts` and `deploy` folders, like in the [Hello World](../developer-guides/hello-world.md)tutorial.
 
 ## Account abstraction
 


### PR DESCRIPTION
Fixes typo in contract and increase amount of ETH sent to multisig wallet to 0.003ETH to make sure there's enough to cover transactions fees. Also mentions this as a possible error.

In addition, fixes broken link and removes warning on top.

Same fixes for the code repo incoming.