### PR TITLE
Fix/DOC-57: typos and minor improvements

### DIFF
--- a/docs/dev/developer-guides/hello-world.md
+++ b/docs/dev/developer-guides/hello-world.md
@@ -15,14 +15,12 @@ The testnet paymaster is just for testing. If you decide to build a project on m
 
 :::
 
-
 ## Prerequisites
 
 For this tutorial, the following programs must be installed:
 
 - `yarn` package manager. `npm` examples will be added soon.
-- `Docker` for compilation.
-- A wallet with sufficient Göerli `ETH` on L1 to pay for bridging funds to zkSync as well as deploying smart contracts. ERC20 tokens on zkSync are required if you want to implement the testnet paymaster.
+- A wallet with sufficient Göerli `ETH` on L1 to pay for bridging funds to zkSync as well as deploying smart contracts. ERC20 tokens on zkSync are required if you want to implement the testnet paymaster. We recommend using [the faucet from the zkSync portal](https://portal.zksync.io/faucet).
 
 ## Initializing the project & deploying a smart contract
 
@@ -46,7 +44,7 @@ require("@matterlabs/hardhat-zksync-solc");
 module.exports = {
   zksolc: {
     version: "1.2.0",
-    compilerSource: "docker",
+    compilerSource: "binary",
     settings: {
       optimizer: {
         enabled: true,
@@ -74,11 +72,9 @@ module.exports = {
 
 ::: warning Tip
 
-If this contract has already complied, you should delete the artifact and cached folders, otherwise, it won't recompile with this compiler version.
+If the contract was already compiled, you should delete the `artifacts-zk` and `cache-zk` folders, otherwise, it won't recompile unless you change the compiler version.
 
 :::
-
-To learn how to verify your smart contract using zkSync block explorer, click [here](../../api/tools/block-explorer/contract-verification.md).
 
 1. Create the `contracts` and `deploy` folders. The former is the place where we will store all the smart contracts' `*.sol` files, and the latter is the place where we will put all the scripts related to deploying the contracts.
 
@@ -168,6 +164,10 @@ yarn hardhat deploy-zksync
 
 In the output, you should see the address the contract was deployed to.
 
+Congratulations! You have deployed a smart contract to zkSync! Now you can visit the [zkSync block explorer](https://explorer.zksync.io/) and search you contract address to confirm it was successfully deployed.
+
+You can find all the details about how to verify your smart contract using zkSync block explorer [here](../../api/tools/block-explorer/contract-verification.md).
+
 ## Front-end integration
 
 ### Setting up the project
@@ -251,7 +251,7 @@ async changeGreeting() {
 },
 ```
 
-On the top of the `<script>` tag, you may see the parts that should be filled with the address of the deployed `Greeter` contract and the path to its ABI. Let's fill these fields in the following sections.
+On the top of the `<script>` tag, you may see the parts that should be filled with the address of the deployed `Greeter` contract and the path to its ABI. We will fill these fields in the following sections.
 
 ```javascript
 // eslint-disable-next-line
@@ -268,7 +268,7 @@ Run the following command on the greeter-tutorial-starter root folder to install
 yarn add ethers zksync-web3
 ```
 
-After that, import both libraries in the ``script` part of the `App.vue` file (right before the contract constant). It should look like this:
+After that, import both libraries in the `script` part of the `App.vue` file (right before the contract constant). It should look like this:
 
 ```javascript
 import {} from "zksync-web3";
@@ -284,7 +284,7 @@ const GREETER_CONTRACT_ABI = []; // TODO: insert the path to the Greeter contrac
 
 Open `./src/App.vue` and set the `GREETER_CONTRACT_ADDRESS` constant equal to the address where the greeter contract was deployed.
 
-To interact with zkSync's smart contract, we also need its ABI.
+To interact with the smart contract we just deployed to zkSync, we also need its ABI. ABI stands for Application Binary Interface and, in short, it's a file that describes all available names and types of the smart contract methods to interact with it.
 
 - Create the `./src/abi.json` file.
 - You can get the contract's ABI in the hardhat project folder from the previous section in the `./artifacts-zk/contracts/Greeter.sol/Greeter.json` file. You should copy the `abi` array and paste it into the `abi.json` file created in the previous step. The file should look roughly the following way:
@@ -520,7 +520,7 @@ Testnet paymaster is purely for demonstration of the feature and won't be availa
 
 The `getOverrides` method returns an empty object when users decide to pay with ether but, when users selects the ERC20 option, it should return the paymaster address and all the information required by it. This is how to do it:
 
-1. Retrieve the address of the testnet paymaster from the zkSycn provider:
+1. Retrieve the address of the testnet paymaster from the zkSync provider:
 
 ```javascript
 async getOverrides() {
@@ -561,7 +561,6 @@ async getOverrides() {
 ```
 
 3. Now, what is left is to encode the paymasterInput following the [protocol requirements](./transactions/aa.md#testnet-paymaster) and return the needed overrides:
-
 
 ```javascript
 async getOverrides() {

--- a/docs/dev/developer-guides/hello-world.md
+++ b/docs/dev/developer-guides/hello-world.md
@@ -17,9 +17,7 @@ The testnet paymaster is just for testing. If you decide to build a project on m
 
 ## Prerequisites
 
-For this tutorial, the following programs must be installed:
-
-- `yarn` package manager. `npm` examples will be added soon.
+- `yarn` package manager. [Here is the installation guide](https://yarnpkg.com/getting-started/install)(`npm` examples will be added soon.)
 - A wallet with sufficient Göerli `ETH` on L1 to pay for bridging funds to zkSync as well as deploying smart contracts. ERC20 tokens on zkSync are required if you want to implement the testnet paymaster. We recommend using [the faucet from the zkSync portal](https://portal.zksync.io/faucet).
 
 ## Initializing the project & deploying a smart contract

--- a/docs/dev/developer-guides/hello-world.md
+++ b/docs/dev/developer-guides/hello-world.md
@@ -164,7 +164,7 @@ In the output, you should see the address the contract was deployed to.
 
 Congratulations! You have deployed a smart contract to zkSync! Now you can visit the [zkSync block explorer](https://explorer.zksync.io/) and search you contract address to confirm it was successfully deployed.
 
-You can find all the details about how to verify your smart contract using zkSync block explorer [here](../../api/tools/block-explorer/contract-verification.md).
+[This guide](../../api/tools/block-explorer/contract-verification.md) explains how to verify your smart contract using the zkSync block explorer.
 
 ## Front-end integration
 

--- a/docs/dev/developer-guides/hello-world.md
+++ b/docs/dev/developer-guides/hello-world.md
@@ -249,7 +249,7 @@ async changeGreeting() {
 },
 ```
 
-On the top of the `<script>` tag, you may see the parts that should be filled with the address of the deployed `Greeter` contract and the path to its ABI. We will fill these fields in the following sections.
+At the top of the `<script>` tag, you may see the parts that should be filled with the address of the deployed `Greeter` contract and the path to its ABI. We will fill these fields in the following sections.
 
 ```javascript
 // eslint-disable-next-line

--- a/docs/dev/developer-guides/transactions/aa.md
+++ b/docs/dev/developer-guides/transactions/aa.md
@@ -3,11 +3,11 @@
 ## Introduction
 
 On Ethereum there are two types of accounts: [externally owned accounts (EOAs)](https://ethereum.org/en/developers/docs/accounts/#externally-owned-accounts-and-key-pairs) and [contracts accounts](https://ethereum.org/en/developers/docs/accounts/#contract-accounts).
-The former type is the only one that can initiate transactions, 
+The former type is the only one that can initiate transactions,
 while the latter is the only one that can implement arbitrary logic. For some use-cases, like smart-contract wallets or privacy protocols, this difference can create a lot of friction.
 As a result, such applications require L1 relayers, e.g. an EOA to help facilitate transactions from a smart-contract wallet.
 
-Accounts in zkSync 2.0 can initiate transactions, like an EOA, but can also have arbitrary logic implemented in them, like a smart contract. This feature is called "account 
+Accounts in zkSync 2.0 can initiate transactions, like an EOA, but can also have arbitrary logic implemented in them, like a smart contract. This feature is called "account
 abstraction" and it aims to resolve the issues described above.
 
 ::: warning Unstable feature
@@ -30,37 +30,37 @@ The account abstraction protocol on zkSync is very similar to [EIP4337](https://
 
 ::: warning Changes are expected
 
-The current model has some important drawbacks: it does not allow custom wallets to send multiple transactions at the same time, while keeping a deterministic ordering. For 
-EOAs the nonces are expected to be sequentially growing, while for the custom accounts the order of transactions can not be determined for sure. 
+The current model has some important drawbacks: it does not allow custom wallets to send multiple transactions at the same time, while keeping a deterministic ordering. For
+EOAs the nonces are expected to be sequentially growing, while for the custom accounts the order of transactions can not be determined for sure.
 
-In the future, we plan to switch to a model where the accounts could choose whether they would want to have sequential nonce ordering (the same as EOA) or they want to have arbitrary ordering.  
+In the future, we plan to switch to a model where the accounts could choose whether they would want to have sequential nonce ordering (the same as EOA) or they want to have arbitrary ordering.
 
 :::
 
-One of the important invariants of every blockchain is that each transaction has a unique hash. Holding this property with an arbitrary account abstraction is not trivial, 
-though accounts can, in general, accept multiple identical transactions. Even though these transactions would be technically valid by the rules of the blockchain, violating 
+One of the important invariants of every blockchain is that each transaction has a unique hash. Holding this property with an arbitrary account abstraction is not trivial,
+though accounts can, in general, accept multiple identical transactions. Even though these transactions would be technically valid by the rules of the blockchain, violating
 hash uniqueness would be very hard for indexers and other tools to process.
 
 There needs to be a solution on the protocol level that is both cheap for users and robust in case of a malicious operator. One of the easiest ways to ensure that transaction hashes do not repeat is to have a pair (sender, nonce) always unique.
 
 The following protocol is used:
 
-- Before each transaction starts, the system queries the [NonceHolder](../contracts/system-contracts.md#inonceholder) to check whether the provided nonce has already been used or not. 
+- Before each transaction starts, the system queries the [NonceHolder](../contracts/system-contracts.md#inonceholder) to check whether the provided nonce has already been used or not.
 - If the nonce has not been used yet, the transaction validation is run. The provided nonce is expected to be marked as "used" during this time.
 - After the validation, the system checks whether this nonce is now marked as used.
 
-Users will be allowed to use any 256-bit number as nonce and they can put any non-zero value under the corresponding key in the system contract. This is already supported by 
-the protocol, but not on the server side. 
+Users will be allowed to use any 256-bit number as nonce and they can put any non-zero value under the corresponding key in the system contract. This is already supported by
+the protocol, but not on the server side.
 
-More documentation on various interactions with the `NonceHolder` system contract as well as tutorials will be available once support on the server side is released. For now, 
+More documentation on various interactions with the `NonceHolder` system contract as well as tutorials will be available once support on the server side is released. For now,
 it is recommended to only use the `incrementNonceIfEquals` method, which practically enforces the sequential ordering of nonces.
 
 ### Standardizing transaction hashes
 
 In the future, it is planned to support efficient proofs of transaction inclusion on zkSync. This would require us to calculate the transaction's hash in the [bootloader](..
-/contracts/system-contracts.md#bootloader). Since these calculations won't be free to the user, it is only fair to include the transaction's hash in the interface of the AA 
-methods (in case the accounts may need this value for some reason). That's why all the methods of the `IAccount` and `IPaymaster` interfaces, which are described below, 
-contain the hash of the transaction as well as the recommended signed digest (the digest that is signed by EOAs for this transaction). 
+/contracts/system-contracts.md#bootloader). Since these calculations won't be free to the user, it is only fair to include the transaction's hash in the interface of the AA
+methods (in case the accounts may need this value for some reason). That's why all the methods of the `IAccount` and `IPaymaster` interfaces, which are described below,
+contain the hash of the transaction as well as the recommended signed digest (the digest that is signed by EOAs for this transaction).
 
 ### IAccount interface
 
@@ -74,17 +74,17 @@ Each account is recommended to implement the [IAccount](https://github.com/matte
 
 ### IPaymaster interface
 
-Like in EIP4337, our account abstraction protocol supports paymasters: accounts that can compensate for other accounts' transactions execution. You can read more about them 
+Like in EIP4337, our account abstraction protocol supports paymasters: accounts that can compensate for other accounts' transactions execution. You can read more about them
 [here](#paymasters).
 
 Each paymaster should implement the [IPaymaster](https://github.com/matter-labs/v2-testnet-contracts/blob/main/l2/system-contracts/interfaces/IPaymaster.sol) interface. It contains the following two methods:
 
 - `validateAndPayForPaymasterTransaction` is mandatory and will be used by the system to determine if the paymaster approves paying for this transaction. If the paymaster is willing to pay for the transaction, this method must send at least `tx.gasprice * tx.ergsLimit` to the operator. It should return the `context` that will be one of the call parameters to the `postOp` method.
-- `postOp` is optional and will be called after the transaction has been executed. Note that unlike EIP4337, there *is no guarantee that this method will be called*. In particular, this method won't be called if the transaction has failed with `out of gas` error. It takes four parameters: the context returned by the `validateAndPayForPaymasterTransaction` method, the transaction itself, whether the execution of the transaction succeeded, and also the maximum amount of ergs the paymaster might be refunded with. More documentation on refunds will be available once their support is added to zkSync.
+- `postOp` is optional and will be called after the transaction has been executed. Note that unlike EIP4337, there _is no guarantee that this method will be called_. In particular, this method won't be called if the transaction has failed with `out of gas` error. It takes four parameters: the context returned by the `validateAndPayForPaymasterTransaction` method, the transaction itself, whether the execution of the transaction succeeded, and also the maximum amount of ergs the paymaster might be refunded with. More documentation on refunds will be available once their support is added to zkSync.
 
 ### Reserved fields of the `Transaction` struct with special meaning
 
-Note that each of the methods above accept the [Transaction](https://github.com/matter-labs/v2-testnet-contracts/blob/0e1c95969a2f92974370326e4430f03e417b25e7/l2/system-contracts/TransactionHelper.sol#L15) struct. 
+Note that each of the methods above accept the [Transaction](https://github.com/matter-labs/v2-testnet-contracts/blob/0e1c95969a2f92974370326e4430f03e417b25e7/l2/system-contracts/TransactionHelper.sol#L15) struct.
 While some of its fields are self-explanatory, there are also 6 `reserved` fields, the meaning of each is defined by the transaction's type. We decided to not give these fields names, since they might be unneeded in some future transaction types. For now, the convention is:
 
 - `reserved[0]` is the nonce.
@@ -108,7 +108,7 @@ During the validation step, the account should decide whether it accepts the tra
 
 **Step 4 (paymaster).** The system calls the `prePaymaster` method of the sender. If this call does not revert, then the `validateAndPayForPaymasterTransaction` method of the paymaster is called. If it does not revert too, proceed to the next step.
 
-**Step 5.** The system verifies that the bootloader has received at least `tx.ergsPrice * tx.ergsLimit` ETH to the bootloader. If it is the case, the verification is considered 
+**Step 5.** The system verifies that the bootloader has received at least `tx.ergsPrice * tx.ergsLimit` ETH to the bootloader. If it is the case, the verification is considered
 complete and we can proceed to the next step.
 
 #### The execution step
@@ -117,13 +117,13 @@ The execution step is considered responsible for the actual execution of the tra
 
 **Step 6.** The system calls the `executeTransaction` method of the account.
 
-**Step 7. (only in case the transaction has a paymaster)** The `postOp` method of the paymaster is called. This step should typically be used for refunding the sender the 
+**Step 7. (only in case the transaction has a paymaster)** The `postOp` method of the paymaster is called. This step should typically be used for refunding the sender the
 unused ergs in case the paymaster was used to facilitate paying fees in ERC-20 tokens.
 
 ### Fees
 
 In EIP4337 you can see three types of gas limits: `verificationGas`, `executionGas`, `preVerificationGas`, that describe the gas limit for the different steps of the transaction inclusion in a block.
-zkSync 2 has only a single field, `ergsLimit`, that covers the fee for all three. When submitting a transaction, make sure that `ergsLimit` is enough to cover verification, 
+zkSync 2 has only a single field, `ergsLimit`, that covers the fee for all three. When submitting a transaction, make sure that `ergsLimit` is enough to cover verification,
 paying the fee (the ERC20 transfer mentioned above), and the actual execution itself.
 
 By default, calling `estimateGas` adds a constant to cover charging the fee and the signature verification for EOA accounts.
@@ -132,11 +132,11 @@ By default, calling `estimateGas` adds a constant to cover charging the fee and 
 
 For the sake of security, both `NonceHolder` and the `ContractDeployer` system contracts can only be called with a special `isSystem` flag. You can read more about it [here](../contracts/system-contracts.md#protected-access-to-some-of-the-system-contracts). To make a call with this flag, the `systemCall` method of the [SystemContractsCaller](https://github.com/matter-labs/v2-testnet-contracts/blob/sb-system-contracts-for-new-update/l2/system-contracts/SystemContractsCaller.sol) library should be used.
 
-Using this library is practically a must when developing custom accounts since this is the only way to call non-view methods of the `NonceHolder` system contract. Also, you will have to use this library if you want to allow users to deploy contracts of their own. You can use the [implementation](https://github.com/matter-labs/v2-testnet-contracts/blob/sb-system-contracts-for-new-update/l2/system-contracts/DefaultAccount.sol) of the EOA account as a reference. 
+Using this library is practically a must when developing custom accounts since this is the only way to call non-view methods of the `NonceHolder` system contract. Also, you will have to use this library if you want to allow users to deploy contracts of their own. You can use the [implementation](https://github.com/matter-labs/v2-testnet-contracts/blob/sb-system-contracts-for-new-update/l2/system-contracts/DefaultAccount.sol) of the EOA account as a reference.
 
 ## Extending EIP4337
 
-To provide DoS protection for the operator, EIP4337 imposes several [restrictions](https://eips.ethereum.org/EIPS/eip-4337#simulation) on the validation step of the account. 
+To provide DoS protection for the operator, EIP4337 imposes several [restrictions](https://eips.ethereum.org/EIPS/eip-4337#simulation) on the validation step of the account.
 Most of them, especially those regarding the forbidden opcodes, are still relevant. However, several restrictions have been lifted for better UX.
 
 ### Extending the allowed opcodes
@@ -145,9 +145,9 @@ Most of them, especially those regarding the forbidden opcodes, are still releva
 
 ### Extending the set of slots that belong to a user
 
-In the original EIP, the `validateTransaction` step of the AA allows the account to read only the storage slots of its own. However, there are slots that *semantically* belong to that user but are actually located on another contract’s addresses. A notable example is `ERC20` balance.
+In the original EIP, the `validateTransaction` step of the AA allows the account to read only the storage slots of its own. However, there are slots that _semantically_ belong to that user but are actually located on another contract’s addresses. A notable example is `ERC20` balance.
 
-This limitation provides DDoS safety by ensuring that the slots used for validation by various accounts *do not overlap*, so there is no need for them to *actually* belong to the account’s storage.
+This limitation provides DDoS safety by ensuring that the slots used for validation by various accounts _do not overlap_, so there is no need for them to _actually_ belong to the account’s storage.
 
 To enable reading the user's ERC20 balance or allowance on the validation step, the following types of slots will be allowed for an account with address `A` on the validation step:
 
@@ -162,20 +162,20 @@ In the future, we might even allow time-bound transactions, e.g. allow checking 
 
 ## Building custom accounts
 
-As already mentioned above, each account should implement the [IAccount](#iaccount-interface) interface. 
+As already mentioned above, each account should implement the [IAccount](#iaccount-interface) interface.
 
-An example of the implementation of the AA interface is the [implementation](https://github.com/matter-labs/v2-testnet-contracts/blob/6a93ff85d33dfff0008624eb9777d5a07a26c55d/l2/system-contracts/DefaultAA.sol#L16) of the EOA account. 
+An example of the implementation of the AA interface is the [implementation](https://github.com/matter-labs/v2-testnet-contracts/blob/6a93ff85d33dfff0008624eb9777d5a07a26c55d/l2/system-contracts/DefaultAA.sol#L16) of the EOA account.
 Note that this account, just like standard EOA accounts on Ethereum, successfully returns empty value whenever it is called by an external address, while this may not be the behaviour that you would like for your account.
 
 ### EIP1271
 
-If you are building a smart wallet, we also _highly encourage_ you to implement the [EIP1271](https://eips.ethereum.org/EIPS/eip-1271) signature-validation scheme. 
+If you are building a smart wallet, we also _highly encourage_ you to implement the [EIP1271](https://eips.ethereum.org/EIPS/eip-1271) signature-validation scheme.
 This is the standard that is endorsed by the zkSync team. It is used in the signature-verification library described below in this section.
 
 ### The deployment process
 
-The process of deploying account logic is very similar to the one of deploying a smart contract. 
-In order to protect smart contracts that do not want to be treated as an account, a different method of the deployer system contract should be used to do it. 
+The process of deploying account logic is very similar to the one of deploying a smart contract.
+In order to protect smart contracts that do not want to be treated as an account, a different method of the deployer system contract should be used to do it.
 Instead of using `create`/`create2`, you should use the `createAccount`/`create2Account` methods of the deployer system contract.
 
 Here is an example of how to deploy account logic using the `zksync-web3` SDK:
@@ -204,12 +204,12 @@ In order to protect the system from a DoS threat, the verification step must hav
 
 Transactions that violate the rules above will not be accepted by the API, though these requirements can not be enforced on the circuit/VM level and do not apply to L1->L2 transactions.
 
-To let you try out the feature faster, we decided to release account abstraction publicly before fully implementing the limitations' checks for the verification step of the account. 
+To let you try out the feature faster, we decided to release account abstraction publicly before fully implementing the limitations' checks for the verification step of the account.
 Currently, your transactions may pass through the API despite violating the requirements above, but soon this will be changed.
 
 ### Nonce holder contract
 
-For optimization purposes, both [tx nonce and the deployment nonce](../contracts/contracts.md#differences-in-create-behaviour) are put in one storage slot inside the [NonceHolder](../contracts/system-contracts.md#inonceholder) system contracts. 
+For optimization purposes, both [tx nonce and the deployment nonce](../contracts/contracts.md#differences-in-create-behaviour) are put in one storage slot inside the [NonceHolder](../contracts/system-contracts.md#inonceholder) system contracts.
 In order to increment the nonce of your account, it is highly recommended to call the [incrementNonceIfEquals](https://github.com/matter-labs/v2-testnet-contracts/blob/0e1c95969a2f92974370326e4430f03e417b25e7/l2/system-contracts/interfaces/INonceHolder.sol#L10) function and pass the value of the nonce provided in the transaction.
 
 This is one of the whitelisted calls, where the account logic is allowed to call outside smart contracts.
@@ -235,13 +235,12 @@ const sentTx = await zksyncProvider.sendTransaction(serializedTx);
 
 ## Paymasters
 
-Imagine being able to pay fees for users of your protocol! Paymasters are accounts that can compensate for other accounts' transactions. The other important use-case of 
+Imagine being able to pay fees for users of your protocol! Paymasters are accounts that can compensate for other accounts' transactions. The other important use-case of
 paymasters is to facilitate paying fees in ERC20 tokens. While ETH is the formal fee token in zkSync, paymasters can provide the ability to exchange ERC20 tokens to ETH on the fly.
 
 If users want to interact with a paymaster, they should provide the non-zero `paymaster` address in their EIP712 transaction. The input data to the paymaster is provided in the `paymasterInput` field of the paymaster.
 
 ### Paymaster verification rules
-
 
 ::: warning Not implemented yet
 
@@ -249,7 +248,7 @@ The verification rules are not fully enforced right now. Even if your paymaster 
 
 :::
 
-Since multiple users should be allowed to access the same paymaster, malicious paymasters *can* do a DoS attack on our system. To work around this, a system similar to the [EIP4337 reputation scoring](https://eips.ethereum.org/EIPS/eip-4337#reputation-scoring-and-throttlingbanning-for-paymasters) will be used.
+Since multiple users should be allowed to access the same paymaster, malicious paymasters _can_ do a DoS attack on our system. To work around this, a system similar to the [EIP4337 reputation scoring](https://eips.ethereum.org/EIPS/eip-4337#reputation-scoring-and-throttlingbanning-for-paymasters) will be used.
 
 Unlike in the original EIP, paymasters are allowed to touch any storage slots. Also, the paymaster won't be throttled if either of the following is true:
 
@@ -260,19 +259,19 @@ Unlike in the original EIP, paymasters are allowed to touch any storage slots. A
 
 While some paymasters can trivially operate without any interaction from users (e.g. a protocol that always pays fees for their users), some require active participation from the transaction's sender. A notable example is a paymaster that swaps users' ERC20 tokens to ETH as it requires the user to set the necessary allowance to the paymaster.
 
-The account abstraction protocol by itself is generic and allows both accounts and paymasters to implement arbitrary interactions. However, the code of default accounts (EOAs) is constant, but we still want them to be able to participate in the ecosystem of custom accounts and paymasters. That's why we have standardized the `paymasterInput` field of the transaction to cover the most common uses-cases of the paymaster feature. 
+The account abstraction protocol by itself is generic and allows both accounts and paymasters to implement arbitrary interactions. However, the code of default accounts (EOAs) is constant, but we still want them to be able to participate in the ecosystem of custom accounts and paymasters. That's why we have standardized the `paymasterInput` field of the transaction to cover the most common uses-cases of the paymaster feature.
 
 Your accounts are free to implement or not implement the support for these flows. However, this is highly encouraged to keep the interface the same for both EOAs and custom accounts.
 
 #### General paymaster flow
 
-It should be used if no prior actions are required from the user for the paymaster to operate. 
+It should be used if no prior actions are required from the user for the paymaster to operate.
 
-The `paymasterInput` field must be encoded as a call to a function with the following interface: 
+The `paymasterInput` field must be encoded as a call to a function with the following interface:
 
 ```solidity
 function general(bytes calldata data);
-``` 
+```
 
 EOA accounts will do nothing and the paymaster can interpret this `data` in any way.
 
@@ -282,15 +281,15 @@ It should be used if the user is required to set certain allowance to a token fo
 
 ```solidity
 function approvalBased(
-    address _token, 
-    uint256 _minAllowance, 
+    address _token,
+    uint256 _minAllowance,
     bytes calldata _innerInput
 )
 ```
 
 The EOA will ensure that the allowance of the `_token` towards the paymaster is set to at least `_minAllowance`. The paymaster is free to interpret the `_innerInput` however it wants to.
 
-If you are developing a paymaster, you *should not* trust the transaction sender to honestly behave (e.g. provide the required allowance with the `approvalBased` flow). These flows serve mostly as instructions to EOAs and the requirements should always be double-checked by the paymaster.
+If you are developing a paymaster, you _should not_ trust the transaction sender to honestly behave (e.g. provide the required allowance with the `approvalBased` flow). These flows serve mostly as instructions to EOAs and the requirements should always be double-checked by the paymaster.
 
 #### Working with paymaster flows using `zksync-web3` SDK
 
@@ -300,13 +299,13 @@ The `zksync-web3` SDK provides [methods](../../../api/js/utils.md#encoding-payma
 
 To let users experience using with paymasters on testnet, as well as to keep supporting paying fees in ERC20 tokens, the Matter Labs team provides the testnet paymaster, that enables paying fees in ERC20 token at a 1:1 exchange rate with ETH (i.e. one unit of this token is equal to 1 wei of ETH).
 
-The paymaster supports only the [approval based](#approval-based-paymaster-flow) paymaster flow and requires that the `token` param is equal to the token being swapped and `minAllowance` to equal to least `tx.maxFeePerErg * tx.ergsLimit`. 
+The paymaster supports only the [approval based](#approval-based-paymaster-flow) paymaster flow and requires that the `token` param is equal to the token being swapped and `minAllowance` to equal to least `tx.maxFeePerErg * tx.ergsLimit`.
 
-An example of how to use testnet paymaster can be seen in the [hello world](../hello-world.md#paying-fees-using-testnet-paymaster) tutorial.
+An example of how to use testnet paymaster can be seen in the [quickstart](../hello-world.md#paying-fees-using-testnet-paymaster) tutorial.
 
 ## `aa-signature-checker`
 
-Your project can start preparing for native AA support. We highly encourage you to do so, since it will allow you to onboard hundreds of thousands of users (e.g. Argent users that already use the first version of zkSync). 
+Your project can start preparing for native AA support. We highly encourage you to do so, since it will allow you to onboard hundreds of thousands of users (e.g. Argent users that already use the first version of zkSync).
 We expect that in the future even more users will switch to smart wallets.
 
 One of the most notable differences between various types of accounts to be built is different signature schemes. We expect accounts to support the [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) standard. Our team has created a utility library for verifying account signatures. Currently, it only supports ECDSA signatures, but we will add support for EIP-1271 very soon as well.

--- a/docs/dev/fundamentals/testnet.md
+++ b/docs/dev/fundamentals/testnet.md
@@ -31,7 +31,7 @@ The only other place where using zkSync SDK is required is during contract deplo
 
 ## Quickstart on zkSync
 
-Check out our step-by-step [quickstart tutorial](../developer-guides/hello-world.md), where you will learn:
+Check out our step-by-step [quickstart guide](../developer-guides/hello-world.md), where you will learn:
 
 - How to install zkSync hardhat plugin and deploy smart contracts with it.
 - How to build the front-end for your dApp using the `zksync-web3` library.

--- a/docs/dev/fundamentals/testnet.md
+++ b/docs/dev/fundamentals/testnet.md
@@ -29,7 +29,7 @@ All the existing SDKs for Ethereum will work out of the box and your users will 
 
 The only other place where using zkSync SDK is required is during contract deployment. This can be easily done through our hardhat plugin.
 
-## Quickstart tutorial on zkSync
+## Quickstart on zkSync
 
 Check out our step-by-step [quickstart tutorial](../developer-guides/hello-world.md), where you will learn:
 

--- a/docs/dev/fundamentals/testnet.md
+++ b/docs/dev/fundamentals/testnet.md
@@ -29,9 +29,9 @@ All the existing SDKs for Ethereum will work out of the box and your users will 
 
 The only other place where using zkSync SDK is required is during contract deployment. This can be easily done through our hardhat plugin.
 
-## Hello World on zkSync
+## Quickstart tutorial on zkSync
 
-Check out our step-by-step [tutorial](../developer-guides/hello-world.md), where you will learn:
+Check out our step-by-step [quickstart tutorial](../developer-guides/hello-world.md), where you will learn:
 
 - How to install zkSync hardhat plugin and deploy smart contracts with it.
 - How to build the front-end for your dApp using the `zksync-web3` library.

--- a/docs/dev/tutorials/README.md
+++ b/docs/dev/tutorials/README.md
@@ -4,7 +4,7 @@ Learn how to build dApps on the zkSync protocol with our how-to guides
 
 ## Table of contents
 
-- [Quickstart tutorial](../developer-guides/hello-world.md)
+- [Quickstart](../developer-guides/hello-world.md)
 - [Cross-chain governance](../tutorials/cross-chain-tutorial.md)
 - [Account abstraction](../tutorials/custom-aa-tutorial.md)
 - [Building custom paymasters](../tutorials/custom-paymaster-tutorial.md)

--- a/docs/dev/tutorials/README.md
+++ b/docs/dev/tutorials/README.md
@@ -4,7 +4,7 @@ Learn how to build dApps on the zkSync protocol with our how-to guides
 
 ## Table of contents
 
-- [Hello world](../developer-guides/hello-world.md)
+- [Quickstart tutorial](../developer-guides/hello-world.md)
 - [Cross-chain governance](../tutorials/cross-chain-tutorial.md)
 - [Account abstraction](../tutorials/custom-aa-tutorial.md)
 - [Building custom paymasters](../tutorials/custom-paymaster-tutorial.md)

--- a/docs/dev/tutorials/cross-chain-tutorial.md
+++ b/docs/dev/tutorials/cross-chain-tutorial.md
@@ -7,7 +7,7 @@ This tutorial serves as an example of how to implement L1 to L2 contract interac
 
 ## Preliminaries
 
-In this tutorial, it is assumed that you are already familiar with deploying smart contracts on zkSync. If not, please refer to the first section of the [Hello World](../developer-guides/hello-world.md) tutorial.
+In this tutorial, it is assumed that you are already familiar with deploying smart contracts on zkSync. If not, please refer to the first section of the [quickstart tutorial](../developer-guides/hello-world.md).
 
 It is also assumed that you already have some experience working with Ethereum.
 
@@ -283,7 +283,7 @@ In the output, you should see the address to which the contract was deployed.
 
 ::: tip
 
-You can find more specific details about deploying contracts in the [hello world](../developer-guides/hello-world.md) tutorial or the documentation for the [hardhat plugins](../../api/hardhat/getting-started.md) for zkSync.
+You can find more specific details about deploying contracts in the [quickstart tutorial](../developer-guides/hello-world.md) or the documentation for the [hardhat plugins](../../api/hardhat/getting-started.md) for zkSync.
 
 :::
 

--- a/docs/dev/tutorials/cross-chain-tutorial.md
+++ b/docs/dev/tutorials/cross-chain-tutorial.md
@@ -387,7 +387,7 @@ async function main() {
 
 Replace the `<GOVERNANCE-ADDRESS>` and `<WALLET-PRIVATE-KEY>` with the address of the L1 governance smart contract and the private key of the wallet that deployed the governance contract respectively.
 
-5. To interact with the zkSync bridge, we need its L1 address. While on mainnet you may want to set the address of the zkSync smart contract as an env variable or a constant, it is worth noticing that you can fetch the smart contract address dynamically.We recommended this approach, especially during the alpha testnet since regenesis may happen and contract addresses might change.
+5. To interact with the zkSync bridge, we need its L1 address. While on mainnet you may want to set the address of the zkSync smart contract as an env variable or a constant, it is worth noticing that you can fetch the smart contract address dynamically. We recommended this approach if you're working on a testnet since regenesis may happen and contract addresses might change.
 
 ```ts
 // Imports

--- a/docs/dev/tutorials/custom-aa-tutorial.md
+++ b/docs/dev/tutorials/custom-aa-tutorial.md
@@ -148,13 +148,13 @@ Let's implement the validation process. It is responsible for validating the sig
 
 To increment the nonce, you should use the `incrementNonceIfEquals` method of the `NONCE_HOLDER_SYSTEM_CONTRACT` system contract. It takes the nonce of the transaction and checks whether the nonce is the same as the provided one. If not, the transaction reverts. Otherwise, the nonce is increased.
 
-Even though the requirements above allow the accounts to touch only their storage slots, accessing your nonce in the `NONCE_HOLDER_SYSTEM_CONTRACT` is a [whitelisted](../developer-guides/transactions/aa.md#extending-the-set-of-slots-that-belong-to-a-user) case, since it behaves in the same way as your storage, it just happened to be in another contract. To call the `NONCE_HOLDER_SYSTEM_CONTRACT`, you should add the following import:
+Even though the requirements above allows the accounts to touch only their storage slots, accessing your nonce in the `NONCE_HOLDER_SYSTEM_CONTRACT` is a [whitelisted](../developer-guides/transactions/aa.md#extending-the-set-of-slots-that-belong-to-a-user) case, since it behaves in the same way as your storage, it just happened to be in another contract. To call the `NONCE_HOLDER_SYSTEM_CONTRACT`, you should add the following import:
 
 ```solidity
 import '@matterlabs/zksync-contracts/l2/system-contracts/Constants.sol';
 ```
 
-The `TransactionHelper` library (already imported in the example above) can be used to get the hash of the transaction that should be signed. You can also implement your own signature scheme and use a different commitment for the transaction to sign, but in this example, we use the hash provided by this library.
+The `TransactionHelper` library (already imported in the example above) can be used to get the hash of the transaction that should be signed. You can also implement your own signature scheme and use a different commitment for the transaction to sign, but in this example we use the hash provided by this library.
 
 Using the `TransactionHelper` library:
 

--- a/docs/dev/tutorials/custom-aa-tutorial.md
+++ b/docs/dev/tutorials/custom-aa-tutorial.md
@@ -8,7 +8,7 @@ In this tutorial, we build a factory that deploys 2-of-2 multisig accounts.
 It is highly recommended to read about the [design](../developer-guides/transactions/aa.md) of the account abstraction protocol before diving into this tutorial.
 
 It is assumed that you are already familiar with deploying smart contracts on zkSync.
-If not, please refer to the first section of the [Hello World](../developer-guides/hello-world.md) tutorial.
+If not, please refer to the first section of the [quickstart tutorial](../developer-guides/hello-world.md).
 It is also recommended to read the [introduction](../developer-guides/contracts/system-contracts.md) to the system contracts.
 
 ## Installing dependencies
@@ -28,7 +28,7 @@ Since we are working with zkSync contracts, we also need to install the package 
 yarn add @matterlabs/zksync-contracts @openzeppelin/contracts @openzeppelin/contracts-upgradeable
 ```
 
-Also, create the `hardhat.config.ts` config file, `contracts` and `deploy` folders, like in the [Hello World](../developer-guides/hello-world.md) tutorial.
+Also, create the `hardhat.config.ts` config file, `contracts` and `deploy` folders, like in the [quickstart tutorial](../developer-guides/hello-world.md).
 
 ## Account abstraction
 

--- a/docs/dev/tutorials/custom-paymaster-tutorial.md
+++ b/docs/dev/tutorials/custom-paymaster-tutorial.md
@@ -6,7 +6,7 @@ Let's see how we can use the paymaster feature to build a custom paymaster that 
 
 To better understand this page, we recommend you first read up on [account abstraction design](../developer-guides/transactions/aa.md) before diving into this tutorial.
 
-It is assumed that you are already familiar with deploying smart contracts on zkSync. If not, please refer to the first section of the [Hello World](../developer-guides/hello-world.md) tutorial. It is also recommended to read the [introduction](../developer-guides/contracts/system-contracts.md) to the system contracts.
+It is assumed that you are already familiar with deploying smart contracts on zkSync. If not, please refer to the first section of the [quickstart tutorial](../developer-guides/hello-world.md). It is also recommended to read the [introduction](../developer-guides/contracts/system-contracts.md) to the system contracts.
 
 ## Installing dependencies
 
@@ -25,7 +25,7 @@ Since we are working with zkSync contracts, we also need to install the package 
 yarn add @matterlabs/zksync-contracts @openzeppelin/contracts @openzeppelin/contracts-upgradeable
 ```
 
-Create the `hardhat.config.ts` config file, `contracts` and `deploy` folders, like in the [Hello World](../developer-guides/hello-world.md) tutorial.
+Create the `hardhat.config.ts` config file, `contracts` and `deploy` folders, like in the [quickstart tutorial](../developer-guides/hello-world.md).
 
 ## Design
 


### PR DESCRIPTION
Fixes typos found by Anthony.
Changes all references of "Hello world" to Quickstart tutorial
