### PR TITLE
Plugins page and other fixes

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -71,13 +71,7 @@ module.exports = {
           title: "Getting started",
           path: "/dev/fundamentals",
           collapsable: false,
-          children: [
-            "/dev/fundamentals/rollups.md",
-            "/dev/fundamentals/zkSync.md",
-            "/dev/fundamentals/testnet.md",
-            "/dev/fundamentals/faq.md",
-          ],
-
+          children: ["/dev/fundamentals/rollups.md", "/dev/fundamentals/zkSync.md", "/dev/fundamentals/testnet.md", "/dev/fundamentals/faq.md"],
         },
         {
           title: "Understanding zkSync",
@@ -191,7 +185,7 @@ module.exports = {
           path: "/api/hardhat", // optional, which should be a absolute path.
           collapsable: false, // optional, defaults to true
           sidebarDepth: 1,
-          children: ["/api/hardhat/getting-started", "/api/hardhat/reference", "/api/hardhat/testing", "/api/hardhat/compiling-libraries"],
+          children: ["/api/hardhat/getting-started", "/api/hardhat/plugins", "/api/hardhat/testing", "/api/hardhat/compiling-libraries"],
         },
         {
           title: "Block Explorer", // required

--- a/docs/api/hardhat/README.md
+++ b/docs/api/hardhat/README.md
@@ -5,6 +5,6 @@
 ## Table of contents
 
 - [Getting started](./getting-started.md)
-- [Reference](./reference.md)
+- [Plugins & configuration](./plugins.md)
 - [Local testing](./testing.md)
 - [Compiling non-inlinable libraries](./compiling-libraries.md)

--- a/docs/api/hardhat/compiling-libraries.md
+++ b/docs/api/hardhat/compiling-libraries.md
@@ -52,9 +52,9 @@ Error in plugin @matterlabs/hardhat-zksync-solc: LLVM("Library `contracts/MiniMa
 
 That error tells us that the address of the `MiniMath` library should be provided.
 
-To resolve the issue, you need to create _a separate project_, where only the library file will be located. After deploying _only_ the library to zkSync, you should get the address of the deployed library and pass it to the compiler settings. The process of deploying the library is the same as deploying smart contracts. You can learn how to deploy smart contracts on zkSync with the [getting started](./getting-started.md) guide.
+To resolve the issue, you need to create _a separate project_, where only the library file will be located. After deploying _only_ the library to zkSync, you should get the address of the deployed library and pass it to the compiler settings. The process of deploying the library is the same as deploying a smart contract. You can learn how to deploy smart contracts on zkSync in the [getting started](./getting-started.md#write-and-deploy-a-contract) guide.
 
-Let's say that the address of the deployed library is `0xF9702469Dfb84A9aC171E284F71615bd3D3f1EdC`. To pass this address to the compiler parameters, open the `harhdat.config.ts` file of the project where the `Main` contract is located and change its content to the following one:
+Let's say that the address of the deployed library is `0xF9702469Dfb84A9aC171E284F71615bd3D3f1EdC`. To pass this address to the compiler parameters, open the `harhdat.config.ts` file of the project where the `Main` contract is located and add the `libraries` section in the `zksolc` plugin properties:
 
 ```typescript
 require("@matterlabs/hardhat-zksync-deploy");
@@ -70,7 +70,7 @@ module.exports = {
       },
       experimental: {
         dockerImage: "matterlabs/zksolc",
-        tag: "v1.2.0"
+        tag: "v1.2.0",
       },
       libraries: {
         "contracts/MiniMath.sol": {

--- a/docs/api/hardhat/getting-started.md
+++ b/docs/api/hardhat/getting-started.md
@@ -2,28 +2,27 @@
 
 [Hardhat](https://hardhat.org) is an Ethereum development environment, designed for easy smart contract development in Solidity. One of its most prominent features is extendability: you can easily add new plugins to your hardhat project.
 
-zkSync has three plugins for hardhat:
+zkSync has three plugins for Hardhat:
 
-- `@matterlabs/hardhat-zksync-solc` for smart contract compilation using Solidity.
-- `@matterlabs/hardhat-zksync-vyper` for smart contract compilation using Vyper.
-- `@matterlabs/hardhat-zksync-deploy` for smart contract deployment.
+- [@matterlabs/hardhat-zksync-solc](./plugins.md#matterlabs-hardhat-zksync-solc) for smart contract compilation using Solidity.
+- [@matterlabs/hardhat-zksync-vyper](./plugins.md#matterlabs-hardhat-zksync-vyper) for smart contract compilation using Vyper.
+- [@matterlabs/hardhat-zksync-deploy](./plugins.md#matterlabs-hardhat-zksync-deploy) for smart contract deployment.
 
-To learn more about hardhat itself, check out their [documentation](https://hardhat.org/getting-started/).
+To learn more about Hardhat itself, check out [its official documentation](https://hardhat.org/getting-started/).
 
-This tutorial shows how to set up a zkSync Solidity project using a hardhat from scratch.
-If you are using Vyper, check out the [reference](./reference.md#matterlabs-hardhat-zksync-vyper) for our Vyper plugin or the [example](https://github.com/matter-labs/hardhat-zksync/tree/main/examples/vyper-example) in our GitHub repo!
+This tutorial shows how to set up a zkSync Solidity project using Hardhat from scratch.
+If you are using Vyper, check out the [Vyper plugin documentation](./plugins.md#matterlabs-hardhat-zksync-vyper) or [this example](https://github.com/matter-labs/hardhat-zksync/tree/main/examples/vyper-example) in GitHub!
 
 ## Prerequisites
 
 For this tutorial, the following programs must be installed:
 
 - `yarn` package manager. `npm` examples will be added soon.
-- `Docker` for compilation.
-- A wallet with sufficient Görli `ETH` on L1 to pay for bridging funds to zkSync as well as deploying smart contracts.
+- A wallet with sufficient Göerli `ETH` on L1 to pay for bridging funds to zkSync as well as deploying smart contracts. We recommend using [our faucet from the zkSync portal](https://portal.zksync.io/faucet).
 
-## Initializing the project
+## Project setup
 
-1. Initialize the project and install the dependencies. Run the following commands in the terminal:
+1. To initialize the project and install the dependencies, run the following commands in the terminal:
 
 ```
 mkdir greeter-example
@@ -32,7 +31,9 @@ yarn init -y
 yarn add -D typescript ts-node ethers zksync-web3 hardhat @matterlabs/hardhat-zksync-solc @matterlabs/hardhat-zksync-deploy
 ```
 
-`typescript` and `ts-node` are optional - plugins will work fine in a vanilla JavaScript environment. Although, please note that this tutorial _does_ use TypeScript.
+The `typescript` and `ts-node` dependencies are optional - plugins will work fine in a vanilla JavaScript environment. Although, please note that this tutorial _does_ use TypeScript.
+
+## Configuration
 
 2. Create the `hardhat.config.ts` file and paste the following code within it:
 
@@ -43,15 +44,15 @@ require("@matterlabs/hardhat-zksync-solc");
 module.exports = {
   zksolc: {
     version: "1.2.0",
-    compilerSource: "docker",
+    compilerSource: "binary",
     settings: {
       optimizer: {
         enabled: true,
       },
       experimental: {
         dockerImage: "matterlabs/zksolc",
-        tag: "v1.2.0"
-      }
+        tag: "v1.2.0",
+      },
     },
   },
   zkSyncDeploy: {
@@ -69,9 +70,17 @@ module.exports = {
 };
 ```
 
-3. Create the `contracts` and `deploy` folders. The former is the place where all the contracts' `*.sol` files should be stored, and the latter is the place where all the scripts related to deploying the contract will be put.
+::: tip
 
-4. Create the `contracts/Greeter.sol` contract and insert the following code within it:
+To learn more about each specific property in the `hardhat.config.ts` file, check out the [plugins documentation](./plugins.md)
+
+:::
+
+## Write and deploy a contract
+
+3. Create the `contracts` and `deploy` folders. In the `contracts` folder we will store all the smart contract files. In the `deploy` folder we'll place all the scripts related to deploying the contracts.
+
+4. Create the `contracts/Greeter.sol` contract and paste the following code:
 
 ```solidity
 //SPDX-License-Identifier: Unlicense
@@ -94,12 +103,15 @@ contract Greeter {
 }
 ```
 
-5. Compile the contracts with the following command: `yarn hardhat compile`.
+5. Run `yarn hardhat compile` which uses the `hardhat-zksync-solc` plugin to compile the contract. The `artifacts-zk` and `cache-zk` folders will be created in the root directory (instead of the regular Hardhat's `artifacts` and `cache`).
 
-An `artifacts-zk` and `cache-zk` folders were created in the root directory (instead of the regular hardhat's `artifacts` and `cache`).
-These are compilation artifacts, and should not be added to version control.
+::: tip
 
-6. Create the deployment script in the `deploy/deploy.ts`:
+Note that the `artifacts-zk` and `cache-zk` folders contain compilation artifacts and cache, and should not be added to version control, so it's a good practice to include them in the `.gitignore` file of your project.
+
+:::
+
+6. Create the deployment script in `deploy/deploy.ts` with the following code:
 
 ```typescript
 import { utils, Wallet } from "zksync-web3";
@@ -159,16 +171,20 @@ export default async function (hre: HardhatRuntimeEnvironment) {
 }
 ```
 
-7. After replacing the `WALLET-PRIVATE-KEY` text with the `0x`-prefixed private key of your Ethereum wallet, run the script using the following command:
+7. After replacing the `WALLET-PRIVATE-KEY` text with the `0x`-prefixed private key of your Ethereum wallet, run the script using the following command: `yarn hardhat deploy-zksync`. This script will:
 
-```
-yarn hardhat deploy-zksync
-```
+- Transfer 0.001 ETH from Goerli to zkSync.
+- Deploy the `Greeting` contract with the message "Hi there!".
+- Retrieve the message from the contract calling the `greet()` method.
+- Update the greet message in the contract with the `setGreeting()` method.
+- Retrieve the message from the contract again.
+
+**Congratulations! Your Hardhat project is now running on zkSync 🎉**
 
 ## Learn more
 
-- New to `zksync-web3` SDK? [Here](../js) is the documentation.
-- Want to dive deeper into zkSync `hardhat` plugins? Head straight to the [reference](./reference).
+- To learn more about the zkSync Hardhat plugins check out the [plugins documentation](./plugins).
+- If you want to know more about how to interact with zkSync using Javascript, check out the [zksync-web3 Javascript SDK documentation](../js) .
 
 ## Future releases
 

--- a/docs/api/hardhat/getting-started.md
+++ b/docs/api/hardhat/getting-started.md
@@ -4,9 +4,9 @@
 
 zkSync has three plugins for Hardhat:
 
-- [@matterlabs/hardhat-zksync-solc](./plugins.md#matterlabs-hardhat-zksync-solc) for smart contract compilation using Solidity.
-- [@matterlabs/hardhat-zksync-vyper](./plugins.md#matterlabs-hardhat-zksync-vyper) for smart contract compilation using Vyper.
-- [@matterlabs/hardhat-zksync-deploy](./plugins.md#matterlabs-hardhat-zksync-deploy) for smart contract deployment.
+- [@matterlabs/hardhat-zksync-solc](./plugins.md#matterlabs-hardhat-zksync-solc) - used to compile contracts written in Solidity.
+- [@matterlabs/hardhat-zksync-vyper](./plugins.md#matterlabs-hardhat-zksync-vyper) - used to compile contracts written in Vyper.
+- [@matterlabs/hardhat-zksync-deploy](./plugins.md#matterlabs-hardhat-zksync-deploy) - used to deploy smart contracts.
 
 To learn more about Hardhat itself, check out [its official documentation](https://hardhat.org/getting-started/).
 

--- a/docs/api/hardhat/plugins.md
+++ b/docs/api/hardhat/plugins.md
@@ -41,17 +41,17 @@ zksolc: {
 }
 networks: {
   hardhat: {
-    zksync: true
+    zksync: true  // enables zksync in hardhat local network
   }
 }
 ```
 
 - `version` is a field with the version of the `zksolc` compiler. Currently not used.
-- `compilerSource` indicates the compiler source and can be either `docker` or `binary` (recommended). If there's not a compiler binary already installed, the plugin will automatically download it. If `docker` is used, you'd need to run Docker desktop in the background and provide both `dockerImage` and `tag` in the experimental section.
+- `compilerSource` indicates the compiler source and can be either `docker` or `binary` (recommended). If there isnn't a compiler binary already installed, the plugin will automatically download it. If `docker` is used, you'd need to run Docker desktop in the background and provide both `dockerImage` and `tag` in the experimental section.
 - `compilerPath` is a field with the path to the `zksolc` binary. By default, the binary in `$PATH` is used. If `compilerSource` is `docker`, this field is ignored.
 - `dockerImage` and `tag` make up the name of the compiler docker image. If `compilerSource` is `binary`, these fields are ignored.
 - `libraries` if your contract uses non-inlinable libraries as dependencies, they have to be defined here. Learn more about [compiling libraries here](./compiling-libraries.md)
-- `zksync` network option indicates whether zksolc is enabled on a certain network. `false` by default.
+- `zksync` network option indicates whether zksolc is enabled on a certain network. `false` by default. Useful for multichain projects in which you can enable `zksync` only for specific networks.
 
 ### Commands
 
@@ -68,7 +68,7 @@ This plugin is used to provide a convenient interface for compiling Vyper smart 
 [@matterlabs/hardhat-zksync-vyper](https://www.npmjs.com/package/@matterlabs/hardhat-zksync-vyper)
 
 This plugin is used in conjunction with [@nomiclabs/hardhat-vyper](https://www.npmjs.com/package/@nomiclabs/hardhat-vyper).
-To use it, you have to install and import both in the `hardhat.config.ts` file:
+To use it, you have to install and import both plugins in the `hardhat.config.ts` file:
 
 ```javascript
 import "@nomiclabs/hardhat-vyper";
@@ -107,17 +107,17 @@ zkvyper: {
 }
 networks: {
   hardhat: {
-    zksync: true
+    zksync: true  // enables zksync in hardhat local network
   }
 }
 ```
 
 - `version` is a field with the version of the `zkvyper` compiler. Currently not used.
-- `compilerSource` indicates the compiler source and can be either `docker` or `binary` (recommended). If there's not a compiler binary already installed, the plugin will automatically download it. If `docker` is used, you'd need to run Docker desktop in the background and provide both `dockerImage` and `tag` in the experimental section.
+- `compilerSource` indicates the compiler source and can be either `docker` or `binary` (recommended). If there isnn't a compiler binary already installed, the plugin will automatically download it. If `docker` is used, you'd need to run Docker desktop in the background and provide both `dockerImage` and `tag` in the experimental section.
 - `compilerPath` is a field with the path to the `zkvyper` binary. By default, the binary in `$PATH` is used. If `compilerSource` is `docker`, this field is ignored.
 - `dockerImage` and `tag` make up the name of the compiler docker image. If `compilerSource` is `binary`, these fields are ignored.
 - `libraries` if your contract uses non-inlinable libraries as dependencies, they have to be defined here. Learn more about [compiling libraries here](./compiling-libraries.md)
-- `zksync` network option indicates whether zkvyper is enabled on a certain network. `false` by default.
+- `zksync` network option indicates whether zkvyper is enabled on a certain network. `false` by default. Useful for multichain projects in which you can enable `zksync` only for specific networks.
 
 ### Commands
 

--- a/docs/api/hardhat/plugins.md
+++ b/docs/api/hardhat/plugins.md
@@ -1,8 +1,8 @@
-# Reference
+# Plugins
 
-## `@matterlabs/hardhat-zksync-solc`
+## `hardhat-zksync-solc`
 
-This plugin is used to provide a convenient interface for compiling zkSync smart contracts.
+This plugin is used to provide a convenient interface for compiling Solidity smart contracts before deploying them to zkSync 2.0.
 
 ### Npm
 
@@ -24,16 +24,19 @@ This plugin most often will not be used directly in the code.
 
 ### Configuration
 
+This plugin is configured in the `hardhat.config.ts` file of your project. Here is an example
+
 ```typescript
 zksolc: {
-  version: "0.1.5",
-  compilerSource: "docker",
+  version: "1.2.0",
+  compilerSource: "binary",  // binary or docker
   settings: {
-    compilerPath: "zksolc",
+    compilerPath: "zksolc",  // ignored for compilerSource: "docker"
     experimental: {
-      dockerImage: "matterlabs/zksolc",
-      tag: "latest"
-    }
+      dockerImage: "matterlabs/zksolc", // required for compilerSource: "docker"
+      tag: "latest"   // required for compilerSource: "docker"
+    },
+    libraries{} // optional. References to non-inlinable libraries
   }
 }
 networks: {
@@ -44,30 +47,32 @@ networks: {
 ```
 
 - `version` is a field with the version of the `zksolc` compiler. Currently not used.
-- `compilerSource` is a field with the compiler source. It can be either `docker` or `binary`. In the former case, the `dockerImage` value with the name of the compiler docker image should also be provided. In the latter case, the compiler binary should be provided in `$PATH`.
-- `compilerPath` is a field with the path to the `zksolc` binary. If `compilerSource` is `docker`, this field is ignored. By default, the binary in `$PATH` is used.
+- `compilerSource` indicates the compiler source and can be either `docker` or `binary` (recommended). If there's not a compiler binary already installed, the plugin will automatically download it. If `docker` is used, you'd need to run Docker desktop in the background and provide both `dockerImage` and `tag` in the experimental section.
+- `compilerPath` is a field with the path to the `zksolc` binary. By default, the binary in `$PATH` is used. If `compilerSource` is `docker`, this field is ignored.
 - `dockerImage` and `tag` make up the name of the compiler docker image. If `compilerSource` is `binary`, these fields are ignored.
+- `libraries` if your contract uses non-inlinable libraries as dependencies, they have to be defined here. Learn more about [compiling libraries here](./compiling-libraries.md)
 - `zksync` network option indicates whether zksolc is enabled on a certain network. `false` by default.
-
 
 ### Commands
 
-`hardhat compile` -- compiles all the smart contracts in the `contracts` directory and creates `artifacts-zk` folder with all the compilation artifacts, including factory dependencies for the contracts, which could be used for contract deployment. To understand what the factory dependencies are, read more about them in the [Web3 API](../api.md) documentation.
+`hardhat compile` -- compiles all the smart contracts in the `contracts` directory and creates the `artifacts-zk` folder with all the compilation artifacts, including factory dependencies for the contracts, which could be used for contract deployment.
 
-## `@matterlabs/hardhat-zksync-vyper`
+To understand what the factory dependencies are, read more about them in the [Web3 API](../api.md) documentation.
 
-This plugin is used to provide a convenient interface for compiling zkSync smart contracts using Vyper.
+## `hardhat-zksync-vyper`
+
+This plugin is used to provide a convenient interface for compiling Vyper smart contracts before deploying them to zkSync 2.0.
 
 ### Npm
 
 [@matterlabs/hardhat-zksync-vyper](https://www.npmjs.com/package/@matterlabs/hardhat-zksync-vyper)
 
 This plugin is used in conjunction with [@nomiclabs/hardhat-vyper](https://www.npmjs.com/package/@nomiclabs/hardhat-vyper).
-To use it, you have to install and import both:
+To use it, you have to install and import both in the `hardhat.config.ts` file:
 
 ```javascript
-import '@nomiclabs/hardhat-vyper';
-import '@matterlabs/hardhat-zksync-vyper';
+import "@nomiclabs/hardhat-vyper";
+import "@matterlabs/hardhat-zksync-vyper";
 ```
 
 Add the latest version of this plugin to your project with the following command:
@@ -89,13 +94,15 @@ This plugin most often will not be used directly in the code.
 ```typescript
 zkvyper: {
   version: "0.1.0",
-  compilerSource: "docker",
+  compilerSource: "binary",  // binary or docker
   settings: {
-    compilerPath: "zkvyper",
+    compilerPath: "zkvyper",  // ignored for compilerSource: "docker"
     experimental: {
-      dockerImage: "matterlabs/zkvyper",
-      tag: "latest"
-    }
+      dockerImage: "matterlabs/zkvyper",  // required for compilerSource: "docker"
+      tag: "latest"  // required for compilerSource: "docker"
+    },
+    libraries{} // optional. References to non-inlinable libraries
+
   }
 }
 networks: {
@@ -106,19 +113,27 @@ networks: {
 ```
 
 - `version` is a field with the version of the `zkvyper` compiler. Currently not used.
-- `compilerSource` is a field with the compiler source. It can be either `docker` or `binary`. In the former case, the `dockerImage` value with the name of the compiler docker image should also be provided. In the latter case, the compiler binary should be provided in `$PATH`.
-- `compilerPath` is a field with the path to the `zkvyper` binary. If `compilerSource` is `docker`, this field is ignored. By default, the binary in `$PATH` is used.
+- `compilerSource` indicates the compiler source and can be either `docker` or `binary` (recommended). If there's not a compiler binary already installed, the plugin will automatically download it. If `docker` is used, you'd need to run Docker desktop in the background and provide both `dockerImage` and `tag` in the experimental section.
+- `compilerPath` is a field with the path to the `zkvyper` binary. By default, the binary in `$PATH` is used. If `compilerSource` is `docker`, this field is ignored.
 - `dockerImage` and `tag` make up the name of the compiler docker image. If `compilerSource` is `binary`, these fields are ignored.
-- `zksync` network option indicates whether zksolc is enabled on a certain network. `false` by default.
-
+- `libraries` if your contract uses non-inlinable libraries as dependencies, they have to be defined here. Learn more about [compiling libraries here](./compiling-libraries.md)
+- `zksync` network option indicates whether zkvyper is enabled on a certain network. `false` by default.
 
 ### Commands
 
-`hardhat compile` -- compiles all the smart contracts in the `contracts` directory and creates `artifacts-zk` folder with all the compilation artifacts, including factory dependencies for the contracts, which could be used for contract deployment. To understand what the factory dependencies are, read more about them in the [Web3 API](../api.md) documentation.
+`hardhat compile` -- compiles all the smart contracts in the `contracts` directory and creates `artifacts-zk` folder with all the compilation artifacts, including factory dependencies for the contracts, which could be used for contract deployment.
 
-## `@matterlabs/hardhat-zksync-deploy`
+To understand what the factory dependencies are, read more about them in the [Web3 API](../api.md) documentation.
 
-This plugin provides utilities for deploying smart contracts on zkSync with artifacts built by the `@matterlabs/hardhat-zksync-solc` plugin.
+## `hardhat-zksync-deploy`
+
+This plugin provides utilities for deploying smart contracts on zkSync with artifacts built by the `@matterlabs/hardhat-zksync-solc` or `@matterlabs/hardhat-zksync-vyper` plugins.
+
+::: warning
+
+Contracts must be compiled using the official `@matterlabs/hardhat-zksync-solc` or `@matterlabs/hardhat-zksync-vyper` plugins. Contracts compiled with other compilers will fail to deploy to zkSync using this plugin.
+
+:::
 
 ### Npm
 
@@ -136,13 +151,13 @@ yarn add -D @matterlabs/hardhat-zksync-deploy
 
 npm i -D @matterlabs/hardhat-zksync-deploy
 
-````
+```
 
 ### Exports
 
 #### `Deployer`
 
-The main export is the `Deployer` class. It is used to wrap `zksync-web3` Wallet instance and provide a convenient interface for deploying smart contracts based on the artifacts returned by the `@matterlabs/hardhat-zksync-solc` plugin.
+The main export of this plugin is the `Deployer` class. It is used to wrap a `zksync-web3` Wallet instance and provides a convenient interface to deploy smart contracts. Its main methods are:
 
 ```typescript
 class Deployer {
@@ -200,7 +215,7 @@ class Deployer {
     * @param overrides Optional object with additional deploy transaction parameters.
     * @param additionalFactoryDeps Additional contract bytecodes to be added to the factory dependencies list.
     * The fee amount is requested automatically from the zkSync server.
-    * 
+    *
     * @returns A contract object.
     */
   public async deploy(
@@ -218,14 +233,18 @@ class Deployer {
    * @returns Factory dependencies in the format expected by SDK.
    */
   async extractFactoryDeps(artifact: ZkSyncArtifact): Promise<string[]>
-````
+```
+
+To see an example script of how to use a `Deployer` to deploy a contract, check out [deployment section of the quickstart](./getting-started.md#write-and-deploy-a-contract).
 
 ### Configuration
 
-```
+Add the following properies in the `hardhat.config.ts` file:
+
+```json
 zkSyncDeploy: {
   zkSyncNetwork: "https://zksync2-testnet.zksync.dev",
-  ethNetwork: "goerli"
+  ethNetwork: "goerli"  // Can also be the RPC URL of the network
 }
 ```
 
@@ -234,4 +253,10 @@ zkSyncDeploy: {
 
 ### Commands
 
-`hardhat deploy-zksync` -- runs through all the scripts in the `deploy` folder. To run a specific script, add the `--script` argument, e.g. `hardhat deploy-zksync --script 001_deploy.ts` will run script `./deploy/001_deploy.ts`. Note that only scripts in the `deploy` folder can be run by this command.
+`hardhat deploy-zksync` -- runs through all the scripts in the `deploy` folder. To run a specific script, add the `--script` argument, e.g. `hardhat deploy-zksync --script 001_deploy.ts` will run script `./deploy/001_deploy.ts`.
+
+::: tip
+
+Note that deployment scripts must be placed in the `deploy` folder!
+
+:::

--- a/docs/api/hardhat/testing.md
+++ b/docs/api/hardhat/testing.md
@@ -61,11 +61,9 @@ The local zkSync setup comes with some "rich" wallets with large amounts of ETH 
 
 The full list of the addresses of these accounts with the corresponding private keys can be found [here](https://github.com/matter-labs/local-setup/blob/main/rich-wallets.json).
 
-::: tip ERC-20 tokens
+::: warning ERC20 tokens
 
-The initial version of the local node was shipped with several ERC-20 tokens deployed by default.
-
-That's no longer the case and **if you need to interact with ERC-20 tokens, you should deploy them yourself.**
+Rich wallets only have ETH. **If you need to test with ERC20 tokens, you should deploy them yourself.**
 
 If you'd like the local node to come with pre-deployed tokens again, please let us know on our [discord](https://discord.gg/px2aR7w), so we can prioritize accordingly.
 

--- a/docs/api/hardhat/testing.md
+++ b/docs/api/hardhat/testing.md
@@ -6,28 +6,28 @@ zkSync team provides a dockerized local setup for this purpose.
 
 ## Prerequisites
 
-It is required that you have `Docker` and `docker-compose` installed on your computer.
+It is required that you have `Docker` and `docker-compose` installed on your computer. Find the [installation guide here](https://docs.docker.com/get-docker/)
 
-Also, some familiarity with the zkSync hardhat plugin is assumed. If you are newly developing on zkSync with hardhat, a nice introduction is [here](./getting-started.md).
+This guide assumes that you're familiar with the zkSync Hardhat plugins. If you are new developing on zkSync with Hardhat, please check the [getting started section here](./getting-started.md).
 
 ## Installing the testing environment
 
-You can download the dockerized setup with the following command.
+Download the dockerized project with the following command:
 
 ```
 git clone https://github.com/matter-labs/local-setup.git
 ```
 
-## Bootstrapping zkSync
+## Start the local nodes
 
-To bootstrap zkSync locally, run the `start.sh` script:
+To run zkSync locally, run the `start.sh` script:
 
 ```
 cd local-setup
 ./start.sh
 ```
 
-This command will bootstrap three docker containers:
+This command will start three docker containers:
 
 - Postgres (used as the database for zkSync).
 - Local Geth node (used as L1 for zkSync).
@@ -35,9 +35,13 @@ This command will bootstrap three docker containers:
 
 By default, the HTTP JSON-RPC API will run on port `3050`, while WS API will run on port `3051`.
 
-_Note, that it is important that the first `start.sh` script invocation goes uninterrupted. If you face any issues after the bootstrapping process unexpectedly stopped, you should [reset](#resetting-the-zksync-state) the local zkSync state and try again._
+::: warning
 
-## Resetting the zkSync state
+Note, that it is important that the first `start.sh` script invocation goes uninterrupted. If you face any issues after the bootstrapping process unexpectedly stopped, you should [reset](#resetting-the-zksync-state) the local zkSync state and try again.
+
+:::
+
+## Reset the zkSync state
 
 To reset the zkSync state, run the `./clear.sh` script:
 
@@ -52,6 +56,7 @@ sudo ./clear.sh
 ```
 
 ## Rich wallets
+
 The local zkSync setup comes with some "rich" wallets with large amounts of ETH on both L1 and L2.
 
 The full list of the addresses of these accounts with the corresponding private keys can be found [here](https://github.com/matter-labs/local-setup/blob/main/rich-wallets.json).
@@ -60,14 +65,15 @@ The full list of the addresses of these accounts with the corresponding private 
 
 The initial version of the local node was shipped with several ERC-20 tokens deployed by default.
 
-It's no longer the case and if you need to interact with ERC-20 tokens, you should deploy them yourself.
+That's no longer the case and **if you need to interact with ERC-20 tokens, you should deploy them yourself.**
 
 If you'd like the local node to come with pre-deployed tokens again, please let us know on our [discord](https://discord.gg/px2aR7w), so we can prioritize accordingly.
 
 :::
 
-## Using custom database/L1
-To use a custom Postgres database or Layer 1, you should change the environment parameters in the docker-compose file:
+## Using custom database or Ethereum node
+
+To use a custom Postgres database or Layer 1 node, you should change the environment parameters in the docker-compose file:
 
 ```yml
 environment:
@@ -80,10 +86,13 @@ environment:
 
 ## Testing with `mocha` + `chai`
 
-Please note, that since the zkSync node URL is provided in the `hardhat.config.ts`, the best way to use different URLs for production deployment and local testing is to use environment variables. The standard way is to set the `NODE_ENV=test` environment variable before invoking the tests.
+Since the zkSync node URL is provided in the `hardhat.config.ts`, the best way to use different URLs for deployment and local testing is to use environment variables. The standard way is to set the `NODE_ENV=test` environment variable before invoking the tests.
 
-1. Create a new hardhat project and follow the contracts' compilation guide from the [getting started](./getting-started.md) page (steps 1 to 5 of the **Initializing the project** section).
-2. To add the test frameworks, run the following command:
+### Project setup
+
+1. Create a new Hardhat project following the [getting started guide](./getting-started.md) as a reference.
+
+2. To install the test libraries, run the following command:
 
 ```
 yarn add -D mocha chai @types/mocha @types/chai
@@ -97,41 +106,43 @@ yarn add -D mocha chai @types/mocha @types/chai
 }
 ```
 
-This will enable running tests in a hardhat environment with the `NODE_ENV` env variable set as a `test`.
+This will enable running tests in a Hardhat environment with the `NODE_ENV` env variable set as a `test`.
+
+### Configuration
 
 4. Modify `hardhat.config.ts` to use the local node for testing:
 
 ```typescript
-require('@matterlabs/hardhat-zksync-deploy');
-require('@matterlabs/hardhat-zksync-solc');
+require("@matterlabs/hardhat-zksync-deploy");
+require("@matterlabs/hardhat-zksync-solc");
 
 // changes endpoint depending on environment variable
 const zkSyncDeploy =
-  process.env.NODE_ENV == 'test'
+  process.env.NODE_ENV == "test"
     ? {
-        zkSyncNetwork: 'http://localhost:3050',
-        ethNetwork: 'http://localhost:8545',
+        zkSyncNetwork: "http://localhost:3050",
+        ethNetwork: "http://localhost:8545",
       }
     : {
-        zkSyncNetwork: 'https://zksync2-testnet.zksync.dev',
-        ethNetwork: 'goerli',
+        zkSyncNetwork: "https://zksync2-testnet.zksync.dev",
+        ethNetwork: "goerli",
       };
 
 module.exports = {
   zksolc: {
-    version: '1.2.0',
-    compilerSource: 'binary',
+    version: "1.2.0",
+    compilerSource: "binary",
     settings: {
       experimental: {
-        dockerImage: 'matterlabs/zksolc',
-        tag: 'v1.2.0',
+        dockerImage: "matterlabs/zksolc",
+        tag: "v1.2.0",
       },
     },
   },
   // load endpoints
   zkSyncDeploy,
   solidity: {
-    version: '0.8.11',
+    version: "0.8.11",
   },
   networks: {
     hardhat: {
@@ -139,12 +150,13 @@ module.exports = {
     },
   },
 };
-
 ```
 
 Create a `test` folder, where the tests will reside.
 
-5. Now we can write our first test! Create a `test/main.test.ts` file with the following content:
+### Writing test files
+
+5. Now you can write your first test! Create a `test/main.test.ts` file with the following code:
 
 ```ts
 import { expect } from "chai";
@@ -179,11 +191,15 @@ describe("Greeter", function () {
 });
 ```
 
-You can now run the tests with the following command:
+This script deploys the `Greeter` contract created in the [getting started guide](./getting-started.md#write-and-deploy-a-contract) and test that it returns a correct message when calling the `greet()` method, and that the message can be updated with the `setGreeting()` method.
+
+You can now run the test file with the following command:
 
 ```
 yarn test
 ```
+
+**Congratulations! You've ran your first tests locally with zkSync 🎉**
 
 ## Full example
 

--- a/docs/dev/tutorials/README.md
+++ b/docs/dev/tutorials/README.md
@@ -2,11 +2,13 @@
 
 Learn how to build dApps on the zkSync 2.0 protocol with the following step-by-step tutorials.
 
-If you want us to create a tutorial about a specific topic, please let us know on our [Discord](https://discord.gg/px2aR7w).
-
-## List of tutorials
+## List of zkSync 2.0 tutorials
 
 - [Quickstart](../developer-guides/hello-world.md)
 - [Cross-chain governance](../tutorials/cross-chain-tutorial.md)
-- [Account abstraction](../tutorials/custom-aa-tutorial.md)
+- [Account abstraction example](../tutorials/custom-aa-tutorial.md)
 - [Building custom paymasters](../tutorials/custom-paymaster-tutorial.md)
+
+### Tutorial requests
+
+If you want us to create a tutorial about a specific topic, please let us know on our [Discord server](https://discord.gg/px2aR7w).

--- a/docs/dev/tutorials/README.md
+++ b/docs/dev/tutorials/README.md
@@ -1,8 +1,10 @@
 # Tutorials
 
-Learn how to build dApps on the zkSync protocol with our how-to guides
+Learn how to build dApps on the zkSync 2.0 protocol with the following step-by-step tutorials.
 
-## Table of contents
+If you want us to create a tutorial about a specific topic, please let us know on our [Discord](https://discord.gg/px2aR7w).
+
+## List of tutorials
 
 - [Quickstart](../developer-guides/hello-world.md)
 - [Cross-chain governance](../tutorials/cross-chain-tutorial.md)

--- a/docs/dev/tutorials/custom-aa-tutorial.md
+++ b/docs/dev/tutorials/custom-aa-tutorial.md
@@ -62,7 +62,7 @@ contract TwoUserMultisig is IAccount, IERC1271 {
     }
 
     function executeTransaction(bytes32, bytes32, Transaction calldata _transaction) external payable override onlyBootloader {
-        executeTransaction(_transaction);
+        _executeTransaction(_transaction);
 	  }
 
     function _executeTransaction(Transaction calldata _transaction) internal {


### PR DESCRIPTION
Renames "Reference" page to "Plugins".
Improves description of configuration fields like `compilerSource`.
Typos.
Fixes typo in AA tutorial
Adds more content in tutorials index page