### PR TITLE
docs: Updating link for EIP712

### DIFF
--- a/docs/dev/developer-guides/transactions/fee-model.md
+++ b/docs/dev/developer-guides/transactions/fee-model.md
@@ -17,7 +17,7 @@ We want to show the clear distinction between our fee model and the Ethereum one
 
 - **Why can't we have a constant price for storage value?**
 
-As part of the zk rollup security model, zkSync periodically publishes state diffs on Ethereum. The price of that is defined by Ethereum gas price and, as stated, is very volatile. This is why the operator can define the new price in `ergs` for publishing pubdata for each block. Users can provide a cap on the `ergs_per_pubdata` in the [EIP712](../../api/api.md#eip712) transactions.
+As part of the zk rollup security model, zkSync periodically publishes state diffs on Ethereum. The price of that is defined by Ethereum gas price and, as stated, is very volatile. This is why the operator can define the new price in `ergs` for publishing pubdata for each block. Users can provide a cap on the `ergs_per_pubdata` in the [EIP712](https://eips.ethereum.org/EIPS/eip-712) transactions.
 
 ### What does this mean to me?
 


### PR DESCRIPTION
Updated existing link for EIP712. The initial links goes to a 404 error page. 

I hope this helps. :smile:


![Screenshot from 2022-11-20 19-45-53](https://user-images.githubusercontent.com/48914889/202936502-9c04ecaa-eef3-448e-b01e-75583ceeab8e.png)

