### PR TITLE
fix: Remove forum link

### DIFF
--- a/docs/contact.md
+++ b/docs/contact.md
@@ -53,7 +53,6 @@ Chat live with our team and other developers on the official zkSync [Discord](ht
 - [Telegram: user support group](https://t.me/zksync_support)
 - [zkSync Discord](https://join.zksync.dev/)
 - Email user support: **support@zksync.io**
-- [Community Forum](https://community.zksync.io/)
 
 ## Partnerships, integrations and press
 

--- a/docs/dev/troubleshooting/docs-contribution/docs.md
+++ b/docs/dev/troubleshooting/docs-contribution/docs.md
@@ -10,7 +10,6 @@ As collaboration on contribution to zkSync documentation is such an integral par
 - Issues - Communicate about actionable items (things that can be acted upon and completed, such as problems with a specific Documentation page, a need for reorganization, etc.):
     - If you find a problem with a specific page in the zkSync documentation, you can always [edit the page](#edit-or-review-a-documentation-page) to fix it.
     - If you want to discuss a larger problem or propose a major change to the zkSync documentation, you can raise an [issue on Github](https://github.com/matter-labs/zksync-web-v2-docs/issues).
-- Share views and know the latest discussions on our [Community Forum](https://community.zksync.io/).
 - Follow [zkSync on Twitter](https://twitter.com/zksync) to get the latest happenings on zkSync.
 
 <TocHeader />

--- a/docs/dev/troubleshooting/important-links.md
+++ b/docs/dev/troubleshooting/important-links.md
@@ -24,4 +24,3 @@
 ## Questions and support
 
 - [Discord](https://join.zksync.dev/)
-- [Community Forum](https://community.zksync.io/)


### PR DESCRIPTION
Community Forum is no longer working so removed the link in the docs. 