### PR TITLE
Fix the "Proving the inclusion of the message into the L2 block" e2e example

### DIFF
--- a/docs/dev/developer-guides/bridging/l2-l1.md
+++ b/docs/dev/developer-guides/bridging/l2-l1.md
@@ -196,7 +196,6 @@ The following script sends a message from L2 to L1, retrieves the message proof,
 ```typescript
 import * as ethers from "ethers";
 import { Provider, utils, Wallet } from "zksync-web3";
-const SENDER_ADDRESS = "<YOUR_ADDRESS>";
 const TEST_PRIVATE_KEY = "<YOUR_PRIVATE_KEY>";
 
 const MESSAGE = "Some L2->L1 message";
@@ -204,10 +203,11 @@ const MESSAGE = "Some L2->L1 message";
 const l2Provider = new Provider("https://zksync2-testnet.zksync.dev");
 const l1Provider = ethers.getDefaultProvider("goerli");
 
+const wallet = new Wallet(TEST_PRIVATE_KEY, l2Provider, l1Provider);
+
 async function sendMessageToL1(text: string) {
   console.log(`Sending message to L1 with text ${text}`);
   const textBytes = ethers.utils.toUtf8Bytes(MESSAGE);
-  const wallet = new Wallet(TEST_PRIVATE_KEY, l2Provider, l1Provider);
 
   const messengerContract = new ethers.Contract(utils.L1_MESSENGER_ADDRESS, utils.L1_MESSENGER, wallet);
   const tx = await messengerContract.sendToL1(textBytes);
@@ -218,7 +218,7 @@ async function sendMessageToL1(text: string) {
 
 async function getL2MessageProof(blockNumber: ethers.BigNumberish) {
   console.log(`Getting L2 message proof for block ${blockNumber}`);
-  return await l2Provider.getMessageProof(blockNumber, SENDER_ADDRESS, ethers.utils.keccak256(ethers.utils.toUtf8Bytes(MESSAGE)));
+  return await l2Provider.getMessageProof(blockNumber, wallet.address, ethers.utils.keccak256(ethers.utils.toUtf8Bytes(MESSAGE)));
 }
 
 async function proveL2MessageInclusion(l1BatchNumber: ethers.BigNumberish, proof: any, trxIndex: number) {
@@ -228,7 +228,7 @@ async function proveL2MessageInclusion(l1BatchNumber: ethers.BigNumberish, proof
   // all the information of the message sent from L2
   const messageInfo = {
     txNumberInBlock: trxIndex,
-    sender: SENDER_ADDRESS,
+    sender: wallet.address,
     data: ethers.utils.toUtf8Bytes(MESSAGE),
   };
 
@@ -260,23 +260,19 @@ async function main() {
 
   console.log(`Proof is: `, proof);
 
-  const trx = await l2Provider.getTransaction(l2Receipt.hash);
+  const { l1BatchNumber, l1BatchTxIndex } = await l2Provider.getTransactionReceipt(l2Receipt.transactionHash);
 
-  // @ts-ignore
-  console.log("trx.transactionIndex :>> ", trx.transactionIndex);
+  console.log("L1 Index for Tx in block :>> ", l1BatchTxIndex);
 
-  // @ts-ignore
-  const block = await l2Provider.getBlock(trx.blockNumber);
-
-  console.log("L1 Batch for block :>> ", block.l1BatchNumber);
+  console.log("L1 Batch for block :>> ", l1BatchNumber);
 
   // IMPORTANT: This method requires that the block is verified
   // and sent to L1!
   const result = await proveL2MessageInclusion(
-    block.l1BatchNumber,
+    l1BatchNumber,
     proof,
     // @ts-ignore
-    trx.transactionIndex
+    l1BatchTxIndex
   );
 
   console.log("Result is :>> ", result);


### PR DESCRIPTION
Follow-up on the discord thread https://discord.com/channels/722409280497516566/1064852922611011624/1065592019398967326

Summary of changes:
- ``l2Receipt.hash``->`` l2Receipt.transactionHash``
- ``trx.transactionIndex -> l1BatchTxIndex``
- ``l1BatchNumber`` and ``l1BatchTxIndex`` can be retrieved from the L2 Tx receipt after the Tx is finalized