### PR TITLE
info about systemCall and isSystem in compiler AA tutorial

### DIFF
--- a/docs/api/hardhat/hardhat-zksync-solc.md
+++ b/docs/api/hardhat/hardhat-zksync-solc.md
@@ -30,14 +30,16 @@ This plugin is configured in the `hardhat.config.ts` file of your project. Here 
 ```typescript
 zksolc: {
   version: "1.3.1",
-  compilerSource: "binary",  // binary or docker
+  compilerSource: "binary",  // binary or docker (deprecated)
   settings: {
     compilerPath: "zksolc",  // ignored for compilerSource: "docker"
     experimental: {
-      dockerImage: "matterlabs/zksolc", // required for compilerSource: "docker"
-      tag: "latest"   // required for compilerSource: "docker"
+      dockerImage: "matterlabs/zksolc", // Deprecated: used for compilerSource: "docker"
+      tag: "latest"   // Deprecated: used for compilerSource: "docker"
     },
-    libraries:{} // optional. References to non-inlinable libraries
+    libraries:{}, // optional. References to non-inlinable libraries
+    isSystem: false, // optional.  Enables Yul instructions available only for zkSync system contracts and libraries
+    forceEvmla: false // optional. Falls back to EVM legacy assembly if there is a bug with Yul
   }
 }
 networks: {
@@ -47,16 +49,31 @@ networks: {
 }
 ```
 
-- `version` is a field with the version of the `zksolc` compiler. Compiler versions can be found in [the following repository](https://github.com/matter-labs/zksolc-bin).
-- `compilerSource` indicates the compiler source and can be either `docker` or `binary` (recommended). If there isnn't a compiler binary already installed, the plugin will automatically download it. If `docker` is used, you'd need to run Docker desktop in the background and provide both `dockerImage` and `tag` in the experimental section.
-- `compilerPath` (optional) is a field with the path to the `zksolc` binary. By default, the binary in `$PATH` is used. If `compilerSource` is `docker`, this field is ignored.
-- `dockerImage` and `tag` make up the name of the compiler docker image. If `compilerSource` is `binary`, these fields are ignored.
-- `libraries` if your contract uses non-inlinable libraries as dependencies, they have to be defined here. Learn more about [compiling libraries here](./compiling-libraries.md)
-- `zksync` network option indicates whether zksolc is enabled on a certain network. `false` by default. Useful for multichain projects in which you can enable `zksync` only for specific networks.
-
 ::: warning
 
 Compilers are no longer released as Docker images and its usage is no longer recommended. Use the `compilerSource: "binary"` in the Hardhat config file to use the binary instead.
+
+:::
+
+- `version` is a field with the version of the `zksolc` compiler. Compiler versions can be found in [the following repository](https://github.com/matter-labs/zksolc-bin).
+- `compilerSource` indicates the compiler source and can be either `docker` or `binary` (recommended). If there isn't a compiler binary already installed, the plugin will automatically download it. If `docker` is used, you'd need to run Docker desktop in the background and provide both `dockerImage` and `tag` in the experimental section.
+- `compilerPath` (optional) is a field with the path to the `zksolc` binary. By default, the binary in `$PATH` is used. If `compilerSource` is `docker`, this field is ignored.
+- `dockerImage` and `tag` make up the name of the compiler docker image. If `compilerSource` is `binary`, these fields are ignored.
+- `libraries` if your contract uses non-inlinable libraries as dependencies, they have to be defined here. Learn more about [compiling libraries here](./compiling-libraries.md)
+- `isSystem` - required if contracts use enables Yul instructions available only for zkSync system contracts and libraries
+- `forceEvmla` - falls back to EVM legacy assembly if there is a bug with Yul
+- `zksync` network option indicates whether zksolc is enabled on a certain network. `false` by default. Useful for multichain projects in which you can enable `zksync` only for specific networks.
+
+
+::: warning `forceEvmla` usage
+
+Setting the `forceEvmla` field to true can have the following negative impacts:
+
+- No support for recursion.
+- No support for internal function pointers.
+- Contract size or performance impact.
+
+For solidity versions older than 0.8, this setting is enforced by default when compiling.
 
 :::
 

--- a/docs/dev/troubleshooting/changelog.md
+++ b/docs/dev/troubleshooting/changelog.md
@@ -24,10 +24,10 @@ To update your project, follow these steps:
 - If your project uses zksync system contracts, make sure to update the `@matterlabs/zksync-contracts` package as well. There are changes in multiple contract interfaces.
 - Paymasters: 
   - The `ergsPerPubdata: utils.DEFAULT_ERGS_PER_PUBDATA_LIMIT` in the transaction `customData` should be updated to `gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT`. 
-  - Custom paymasters are required to return a magic value after a transaction validation on the `validateAndPayForPaymasterTransaction` method. This value should be `ACCOUNT_VALIDATION_SUCCESS_MAGIC` (available on the `IAccount.sol` interface) if the validation is sucessful, or an empty value `bytes4(0)` if it fails.
+  - Custom paymasters are required to return a magic value after a transaction validation on the `validateAndPayForPaymasterTransaction` method. This value should be `ACCOUNT_VALIDATION_SUCCESS_MAGIC` (available on the `IAccount.sol` interface) if the validation is successful, or an empty value `bytes4(0)` if it fails.
 - If your project uses Account Abstraction, keep in mind that the `IAccount` interface has changed. 
   - We’ve introduced account versioning to allow for future updates. 
-  - Accounts are required to return a magic value after a transaction validation on the `validateTransaction` method. This value should be `ACCOUNT_VALIDATION_SUCCESS_MAGIC` (available on the `IAccount.sol` interface) if the validation is sucessful, or an empty value `bytes4(0)` if it fails.
+  - Accounts are required to return a magic value after a transaction validation on the `validateTransaction` method. This value should be `ACCOUNT_VALIDATION_SUCCESS_MAGIC` (available on the `IAccount.sol` interface) if the validation is successful, or an empty value `bytes4(0)` if it fails.
 - If your smart contracts use any methods from the `SystemContractsCaller` library (like `systemCall`), you'd need to compile them with the `isSystem` flag set to `true` in the `settings` section of `zksolc` inside the `hardhat.config.ts` file.
 - zkSync system contracts have cycle dependencies and might cause issues flattening contracts with `hardhat flatten`. Use the [hardhat verify plugin](../../api/hardhat/hardhat-zksync-verify.md) instead.
 - As with any other regenesis, it will remove all balances and contracts so you’ll need to deposit funds and redeploy your contracts again.

--- a/docs/dev/troubleshooting/changelog.md
+++ b/docs/dev/troubleshooting/changelog.md
@@ -24,6 +24,7 @@ To update your project, follow these steps:
 - If your project uses zksync system contracts, make sure to update the `@matterlabs/zksync-contracts` package as well. There are changes in multiple contract interfaces.
 - Paymasters: The `ergsPerPubdata: utils.DEFAULT_ERGS_PER_PUBDATA_LIMIT` in the transaction `customData` should be updated to `gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT`. Custom paymasters are required to return a magic value after a transaction validation on the `validateAndPayForPaymasterTransaction` method.
 - If your project uses Account Abstraction, keep in mind that the IAccount interface has changed. We’ve introduced account versioning to allow for future updates. Accounts are required to return a magic value after a transaction validation on the `validateTransaction` method.
+- If your smart contracts use any methods from the `SystemContractsCaller` library (like `systemCall`), you'd need to compile them with the `isSystem` flag set to `true` in the `settings` section of `zksolc` inside the `hardhat.config.ts` file.
 - As with any other regenesis, it will remove all balances and contracts so you’ll need to deposit funds and redeploy your contracts again.
 
 If after doing these changes you’re still facing issues, please [create a support ticket in the "dev-support-beta" channed in our Discord](https://join.zksync.dev/).

--- a/docs/dev/troubleshooting/changelog.md
+++ b/docs/dev/troubleshooting/changelog.md
@@ -25,6 +25,7 @@ To update your project, follow these steps:
 - Paymasters: The `ergsPerPubdata: utils.DEFAULT_ERGS_PER_PUBDATA_LIMIT` in the transaction `customData` should be updated to `gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT`. Custom paymasters are required to return a magic value after a transaction validation on the `validateAndPayForPaymasterTransaction` method.
 - If your project uses Account Abstraction, keep in mind that the IAccount interface has changed. We’ve introduced account versioning to allow for future updates. Accounts are required to return a magic value after a transaction validation on the `validateTransaction` method.
 - If your smart contracts use any methods from the `SystemContractsCaller` library (like `systemCall`), you'd need to compile them with the `isSystem` flag set to `true` in the `settings` section of `zksolc` inside the `hardhat.config.ts` file.
+- zkSync system contracts have cycle dependencies and might cause issues flattening contracts with `hardhat flatten`. Use the [hardhat verify plugin](../../api/hardhat/hardhat-zksync-verify.md) instead.
 - As with any other regenesis, it will remove all balances and contracts so you’ll need to deposit funds and redeploy your contracts again.
 
 If after doing these changes you’re still facing issues, please [create a support ticket in the "dev-support-beta" channed in our Discord](https://join.zksync.dev/).

--- a/docs/dev/troubleshooting/changelog.md
+++ b/docs/dev/troubleshooting/changelog.md
@@ -22,8 +22,12 @@ To update your project, follow these steps:
 - Re-compile your project with the latest version of the binary compiler (`v1.3.1`).
 - Update `zksync-web3` to `0.13.x`. All methods that included `ergs` have been renamed to `gas` and some function signatures have changed.
 - If your project uses zksync system contracts, make sure to update the `@matterlabs/zksync-contracts` package as well. There are changes in multiple contract interfaces.
-- Paymasters: The `ergsPerPubdata: utils.DEFAULT_ERGS_PER_PUBDATA_LIMIT` in the transaction `customData` should be updated to `gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT`. Custom paymasters are required to return a magic value after a transaction validation on the `validateAndPayForPaymasterTransaction` method.
-- If your project uses Account Abstraction, keep in mind that the IAccount interface has changed. We’ve introduced account versioning to allow for future updates. Accounts are required to return a magic value after a transaction validation on the `validateTransaction` method.
+- Paymasters: 
+  - The `ergsPerPubdata: utils.DEFAULT_ERGS_PER_PUBDATA_LIMIT` in the transaction `customData` should be updated to `gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT`. 
+  - Custom paymasters are required to return a magic value after a transaction validation on the `validateAndPayForPaymasterTransaction` method. This value should be `ACCOUNT_VALIDATION_SUCCESS_MAGIC` (available on the `IAccount.sol` interface) if the validation is sucessful, or an empty value `bytes4(0)` if it fails.
+- If your project uses Account Abstraction, keep in mind that the `IAccount` interface has changed. 
+  - We’ve introduced account versioning to allow for future updates. 
+  - Accounts are required to return a magic value after a transaction validation on the `validateTransaction` method. This value should be `ACCOUNT_VALIDATION_SUCCESS_MAGIC` (available on the `IAccount.sol` interface) if the validation is sucessful, or an empty value `bytes4(0)` if it fails.
 - If your smart contracts use any methods from the `SystemContractsCaller` library (like `systemCall`), you'd need to compile them with the `isSystem` flag set to `true` in the `settings` section of `zksolc` inside the `hardhat.config.ts` file.
 - zkSync system contracts have cycle dependencies and might cause issues flattening contracts with `hardhat flatten`. Use the [hardhat verify plugin](../../api/hardhat/hardhat-zksync-verify.md) instead.
 - As with any other regenesis, it will remove all balances and contracts so you’ll need to deposit funds and redeploy your contracts again.

--- a/docs/dev/troubleshooting/changelog.md
+++ b/docs/dev/troubleshooting/changelog.md
@@ -28,6 +28,7 @@ To update your project, follow these steps:
   - The `ergsPerPubdata: utils.DEFAULT_ERGS_PER_PUBDATA_LIMIT` in the transaction `customData` should be updated to `gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT`. 
   - Custom paymasters are required to return a magic value after a transaction validation on the `validateAndPayForPaymasterTransaction` method. This value should be `ACCOUNT_VALIDATION_SUCCESS_MAGIC` (available on the `IAccount.sol` interface) if the validation is successful, or an empty value `bytes4(0)` if it fails.
 - If your project uses Account Abstraction, keep in mind that the `IAccount` interface has changed. 
+  - The `prePaymaster` method has been renamed to`prepareForPaymaster`.
   - We’ve introduced account versioning to allow for future updates. 
   - Accounts are required to return a magic value after a transaction validation on the `validateTransaction` method. This value should be `ACCOUNT_VALIDATION_SUCCESS_MAGIC` (available on the `IAccount.sol` interface) if the validation is successful, or an empty value `bytes4(0)` if it fails.
 - If your smart contracts use any methods from the `SystemContractsCaller` library (like `systemCall`), you'd need to compile them with the `isSystem` flag set to `true` in the `settings` section of `zksolc` inside the `hardhat.config.ts` file.

--- a/docs/dev/troubleshooting/changelog.md
+++ b/docs/dev/troubleshooting/changelog.md
@@ -4,10 +4,12 @@
 
 The recent update made several modifications to the system in preparation for the "Fair Onboarding Alpha" milestone. The modifications include:
 
-- a fee mechanism revamp that replaces `ergs` with `gas` to make it easier to understand (after all, we’re all part of the Ethereum ecosystem).
-- updates in the Account Abstraction support;
-- changes in L1 and L2 system contract interfaces.
-- breaking changes in our SDKs where methods and properties that contained `ergs` are renamed `gas`.
+- Revamp in the fee mechanism:
+  - `ergs` have been replaced with `gas` to make it easier to understand (after all, we’re all part of the Ethereum ecosystem).
+  - Gas refunds: transactions are refunded for unused gas. You can see these refunds as token transfers [in the explorer](https://explorer.zksync.io/).
+- Updates in the Account Abstraction and Paymaster interfaces.
+- Changes in L1 and L2 system contract interfaces.
+- Breaking changes in our SDKs where methods and properties that contained `ergs` are renamed `gas`.
 - API error messages now follow the Geth format (more updates coming soon).
 
 **These updates were followed by a system regenesis.**

--- a/docs/dev/tutorials/custom-aa-tutorial.md
+++ b/docs/dev/tutorials/custom-aa-tutorial.md
@@ -35,7 +35,7 @@ The current version of `zksync-web3` uses `ethers v5.7.x` as a peer dependency. 
 Since we are working with zkSync contracts, we also need to install the package with the contracts and its peer dependencies:
 
 ```
-yarn add @matterlabs/zksync-contracts @openzeppelin/contracts @openzeppelin/contracts-upgradeable
+yarn add -D @matterlabs/zksync-contracts @openzeppelin/contracts @openzeppelin/contracts-upgradeable
 ```
 
 Also, create the `hardhat.config.ts` config file, `contracts` and `deploy` folders, like in the [quickstart tutorial](../developer-guides/hello-world.md).

--- a/docs/dev/tutorials/custom-aa-tutorial.md
+++ b/docs/dev/tutorials/custom-aa-tutorial.md
@@ -38,7 +38,34 @@ Since we are working with zkSync contracts, we also need to install the package 
 yarn add -D @matterlabs/zksync-contracts @openzeppelin/contracts @openzeppelin/contracts-upgradeable
 ```
 
-Also, create the `hardhat.config.ts` config file, `contracts` and `deploy` folders, like in the [quickstart tutorial](../developer-guides/hello-world.md).
+Also, create the `hardhat.config.ts` config file, `contracts` and `deploy` folders, similar to the [quickstart tutorial](../developer-guides/hello-world.md). As in this project our contracts will interact with system contracts, we need to include the `isSystem: true` in the compiler settings:
+
+```
+import "@matterlabs/hardhat-zksync-deploy";
+import "@matterlabs/hardhat-zksync-solc";
+
+module.exports = {
+  zksolc: {
+    version: "1.3.1",
+    compilerSource: "binary",
+      settings: {
+        isSystem: true,
+      },
+  },
+  defaultNetwork: "zkSyncTestnet",
+
+  networks: {
+    zkSyncTestnet: {
+      url: "https://zksync2-testnet.zksync.dev",
+      ethNetwork: "goerli", // Can also be the RPC URL of the network (e.g. `https://goerli.infura.io/v3/<API_KEY>`)
+      zksync: true,
+    },
+  },
+  solidity: {
+    version: "0.8.17",
+  },
+};
+```
 
 ::: tip
 

--- a/docs/dev/tutorials/custom-aa-tutorial.md
+++ b/docs/dev/tutorials/custom-aa-tutorial.md
@@ -7,14 +7,6 @@ In this tutorial, we build a factory that deploys 2-of-2 multisig accounts.
 <TOC class="table-of-contents" :include-level="[2,3]" />
 
 
-::: warning
-
-Please note that breaking changes were introduced in `zksync-web3 ^0.13.0`. The API layer now operates with `gas` and the `ergs` concept is only used internally by the VM. 
-
-This tutorial will be updated shortly to reflect those changes.
-
-:::
-
 ## Prerequisite
 
 It is highly recommended to read about the [design](../developer-guides/aa.md) of the account abstraction protocol before diving into this tutorial.
@@ -64,83 +56,194 @@ The skeleton for the contract will look the following way:
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import '@matterlabs/zksync-contracts/l2/system-contracts/interfaces/IAccount.sol';
-import '@matterlabs/zksync-contracts/l2/system-contracts/TransactionHelper.sol';
+import "@matterlabs/zksync-contracts/l2/system-contracts/interfaces/IAccount.sol";
+import "@matterlabs/zksync-contracts/l2/system-contracts/libraries/TransactionHelper.sol";
 
 import "@openzeppelin/contracts/interfaces/IERC1271.sol";
 
+
 contract TwoUserMultisig is IAccount, IERC1271 {
+    // to get transaction hash
+    using TransactionHelper for Transaction;
+
+
+    bytes4 constant EIP1271_SUCCESS_RETURN_VALUE = 0x1626ba7e;
 
     modifier onlyBootloader() {
-        require(msg.sender == BOOTLOADER_FORMAL_ADDRESS, "Only bootloader can call this method");
-        // Continue execution if called from the bootloader.
+        require(
+            msg.sender == BOOTLOADER_FORMAL_ADDRESS,
+            "Only bootloader can call this method"
+        );
+        // Continure execution if called from the bootloader.
         _;
     }
 
-    function validateTransaction(bytes32, bytes32 _suggestedSignedHash, Transaction calldata _transaction) external payable override onlyBootloader {
-        _validateTransaction(_suggestedSignedHash, _transaction);
+
+    function validateTransaction(
+        bytes32,
+        bytes32 _suggestedSignedHash,
+        Transaction calldata _transaction
+    ) external payable override onlyBootloader returns (bytes4 magic) {
+        magic = _validateTransaction(_suggestedSignedHash, _transaction);
     }
 
-    function _validateTransaction(bytes32 _suggestedSignedHash, Transaction calldata _transaction) internal {
-
+    function _validateTransaction(
+        bytes32 _suggestedSignedHash,
+        Transaction calldata _transaction
+    ) internal returns (bytes4 magic) {
+        // TO BE IMPLEMENTED
     }
 
-    function executeTransaction(bytes32, bytes32, Transaction calldata _transaction) external payable override onlyBootloader {
+    function executeTransaction(
+        bytes32,
+        bytes32,
+        Transaction calldata _transaction
+    ) external payable override onlyBootloader {
         _executeTransaction(_transaction);
-	  }
+    }
 
     function _executeTransaction(Transaction calldata _transaction) internal {
-
+        // TO BE IMPLEMENTED
     }
 
-    function executeTransactionFromOutside(Transaction calldata _transaction) external payable {
-        _validateTransaction(_transaction);
+    function executeTransactionFromOutside(Transaction calldata _transaction)
+        external
+        payable
+    {
+        _validateTransaction(bytes32(0), _transaction);
         _executeTransaction(_transaction);
     }
 
-	  bytes4 constant EIP1271_SUCCESS_RETURN_VALUE = 0x1626ba7e;
-
-    function isValidSignature(bytes32 _hash, bytes calldata _signature) public override view returns (bytes4) {
-        return EIP1271_SUCCESS_RETURN_VALUE;
+    function isValidSignature(bytes32 _hash, bytes memory _signature)
+        public
+        view
+        override
+        returns (bytes4 magic)
+    {
+        // TO BE IMPLEMENTED
     }
 
-    function payForTransaction(bytes32, bytes32, Transaction calldata _transaction) external payable override onlyBootloader {
-
+    function payForTransaction(
+        bytes32,
+        bytes32,
+        Transaction calldata _transaction
+    ) external payable override onlyBootloader {
+        // TO BE IMPLEMENTED
     }
 
-    function prePaymaster(bytes32, bytes32, Transaction calldata _transaction) external payable override onlyBootloader {
-
+    function prepareForPaymaster(
+        bytes32, // _txHash
+        bytes32, // _suggestedSignedHash
+        Transaction calldata _transaction
+    ) external payable override onlyBootloader {
+        // TO BE IMPLEMENTED
     }
 
-	receive() external payable {
-        // If the bootloader called the `receive` function, it likely means
-        // that something went wrong and the transaction should be aborted. The bootloader should
-        // only interact through the `validateTransaction`/`executeTransaction` methods.
+    // This function verifies that the ECDSA signature is both in correct format and non-malleable
+    function checkValidECDSASignatureFormat(bytes memory _signature) internal pure returns (bool) {
+        if(_signature.length != 65) {
+            return false;
+        }
+
+        uint8 v;
+		bytes32 r;
+		bytes32 s;
+		// Signature loading code
+		// we jump 32 (0x20) as the first slot of bytes contains the length
+		// we jump 65 (0x41) per signature
+		// for v we load 32 bytes ending with v (the first 31 come from s) then apply a mask
+		assembly {
+			r := mload(add(_signature, 0x20))
+			s := mload(add(_signature, 0x40))
+			v := and(mload(add(_signature, 0x41)), 0xff)
+		}
+		if(v != 27 && v != 28) {
+            return false;
+        }
+
+		// EIP-2 still allows signature malleability for ecrecover(). Remove this possibility and make the signature
+        // unique. Appendix F in the Ethereum Yellow paper (https://ethereum.github.io/yellowpaper/paper.pdf), defines
+        // the valid range for s in (301): 0 < s < secp256k1n ÷ 2 + 1, and for v in (302): v ∈ {27, 28}. Most
+        // signatures from current libraries generate a unique signature with an s-value in the lower half order.
+        //
+        // If your library generates malleable signatures, such as s-values in the upper range, calculate a new s-value
+        // with 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141 - s1 and flip v from 27 to 28 or
+        // vice versa. If your library also generates signatures with 0/1 for v instead 27/28, add 27 to v to accept
+        // these malleable signatures as well.
+        if(uint256(s) > 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0) {
+            return false;
+        }
+
+        return true;
+    }
+    
+    function extractECDSASignature(bytes memory _fullSignature) internal pure returns (bytes memory signature1, bytes memory signature2) {
+        require(_fullSignature.length == 130, "Invalid length");
+
+        signature1 = new bytes(65);
+        signature2 = new bytes(65);
+
+        // Copying the first signature. Note, that we need an offset of 0x20 
+        // since it is where the length of the `_fullSignature` is stored
+        assembly {
+            let r := mload(add(_fullSignature, 0x20))
+			let s := mload(add(_fullSignature, 0x40))
+			let v := and(mload(add(_fullSignature, 0x41)), 0xff)
+
+            mstore(add(signature1, 0x20), r)
+            mstore(add(signature1, 0x40), s)
+            mstore8(add(signature1, 0x60), v)
+        }
+
+        // Copying the second signature.
+        assembly {
+            let r := mload(add(_fullSignature, 0x61))
+            let s := mload(add(_fullSignature, 0x81))
+            let v := and(mload(add(_fullSignature, 0x82)), 0xff)
+
+            mstore(add(signature2, 0x20), r)
+            mstore(add(signature2, 0x40), s)
+            mstore8(add(signature2, 0x60), v)
+        }
+    }
+
+    fallback() external {
+        // fallback of default account shouldn't be called by bootloader under no circumstances
         assert(msg.sender != BOOTLOADER_FORMAL_ADDRESS);
+
+        // If the contract is called directly, behave like an EOA
+    }
+
+    receive() external payable {
+        // If the contract is called directly, behave like an EOA.
+        // Note, that is okay if the bootloader sends funds with no calldata as it may be used for refunds/operator payments
     }
 }
 ```
 
-Note, that only the [bootloader](../developer-guides/contracts/system-contracts.md#bootloader) should be allowed to call the `validateTransaction`/`executeTransaction`/`payForTransaction`/`prePaymaster` methods.
+Note, that only the [bootloader](../developer-guides/contracts/system-contracts.md#bootloader) should be allowed to call the `validateTransaction`/`executeTransaction`/`payForTransaction`/`prepareForPaymaster` methods.
 That's why the `onlyBootloader` modifier is used for them.
 
 The `executeTransactionFromOutside` is needed to allow external users to initiate transactions from this account. The easiest way to implement it is to do the same as `validateTransaction` + `executeTransaction` would do.
 
+In addition, the `checkValidECDSASignatureFormat` and `extractECDSASignature` are helper methods that we'll use in the `isValidSignature` implementation.
+
 ### Signature validation
 
-Firstly, we need to implement the signature validation process. Since we are building a two-account multisig, let's pass its owners' addresses in the constructor. In this tutorial, we use OpenZeppelin's `ECDSA` library for signature validation.
-
-Add the following import:
+Firstly, we need to implement the signature validation process.  In this tutorial, we use OpenZeppelin's `ECDSA` library for signature validation so we'd need to import it:
 
 ```solidity
+// Used for signature validation
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 ```
 
-Also, add the constructor to the contract:
+Since we are building a two-account multisig, let's pass its owners' addresses in the constructor and save them is stata variables:
 
 ```solidity
+// state variables for account owners
 address public owner1;
 address public owner2;
+
 
 constructor(address _owner1, address _owner2) {
     owner1 = _owner1;
@@ -148,22 +251,53 @@ constructor(address _owner1, address _owner2) {
 }
 ```
 
-And then we can implement the `isValidSignature` method in the following way:
+To validate the signature we'll have to:
+
+- check if the lenght of the received signature is correct.
+- extract the two signatures from the received multisig using the helper method `extractECDSASignature`
+- check if both signatures are valid using the helper method `checkValidECDSASignatureFormat`.
+- extract the addresses from the transaction hash and each signature using the `ECDSA.recover` method.
+- check if the addresses extracted match with the owners of the account.
+- return the `EIP1271_SUCCESS_RETURN_VALUE` value on success or `bytes4(0)` if validation fails.
+
+Here is the full implementation of the `isValidSignature` method:
 
 ```solidity
-function isValidSignature(bytes32 _hash, bytes calldata _signature) public override view returns (bytes4) {
-    // The signature is the concatenation of the ECDSA signatures of the owners
-    // Each ECDSA signature is 65 bytes long. That means that the combined signature is 130 bytes long.
-    require(_signature.length == 130, 'Signature length is incorrect');
 
-    address recoveredAddr1 = ECDSA.recover(_hash, _signature[0:65]);
-    address recoveredAddr2 = ECDSA.recover(_hash, _signature[65:130]);
+function isValidSignature(bytes32 _hash, bytes memory _signature)
+    public
+    view
+    override
+    returns (bytes4 magic)
+{
+    magic = EIP1271_SUCCESS_RETURN_VALUE;
 
-    require(recoveredAddr1 == owner1);
-    require(recoveredAddr2 == owner2);
+    if (_signature.length != 130) {
+        // Signature is invalid, but we need to proceed with the signature verification as usual
+        // in order for the fee estimation to work correctly
+        _signature = new bytes(130);
+        
+        // Making sure that the signatures look like a valid ECDSA signature and are not rejected rightaway
+        // while skipping the main verification process.
+        _signature[64] = bytes1(uint8(27));
+        _signature[129] = bytes1(uint8(27));
+    }
 
-    return EIP1271_SUCCESS_RETURN_VALUE;
+    (bytes memory signature1, bytes memory signature2) = extractECDSASignature(_signature);
+
+    if(!checkValidECDSASignatureFormat(signature1) || !checkValidECDSASignatureFormat(signature2)) {
+        magic = bytes4(0);
+    }
+
+    address recoveredAddr1 = ECDSA.recover(_hash, signature1);
+    address recoveredAddr2 = ECDSA.recover(_hash, signature2);
+
+    // Note, that we should abstain from using the require here in order to allow for fee estimation to work
+    if(recoveredAddr1 != owner1 || recoveredAddr2 != owner2) {
+        magic = bytes4(0);
+    }
 }
+
 ```
 
 ### Transaction validation
@@ -175,75 +309,99 @@ To increment the nonce, you should use the `incrementNonceIfEquals` method of th
 Even though the requirements above allows the accounts to touch only their storage slots, accessing your nonce in the `NONCE_HOLDER_SYSTEM_CONTRACT` is a [whitelisted](../developer-guides/aa.md#extending-the-set-of-slots-that-belong-to-a-user) case, since it behaves in the same way as your storage, it just happened to be in another contract. To call the `NONCE_HOLDER_SYSTEM_CONTRACT`, you should add the following import:
 
 ```solidity
-import '@matterlabs/zksync-contracts/l2/system-contracts/Constants.sol';
+// Access zkSync system contracts, in this case for nonce validation vs NONCE_HOLDER_SYSTEM_CONTRACT
+import "@matterlabs/zksync-contracts/l2/system-contracts/Constants.sol";
 ```
 
-The `TransactionHelper` library (already imported in the example above) can be used to get the hash of the transaction that should be signed. You can also implement your own signature scheme and use a different commitment for the transaction to sign, but in this example we use the hash provided by this library.
-
-Using the `TransactionHelper` library:
+Note that since the non-view methods of the `NONCE_HOLDER_SYSTEM_CONTRACT` are required to be called with the `isSystem` flag on, the [systemCallWithPropagatedRevert](https://github.com/matter-labs/v2-testnet-contracts/blob/main/l2/system-contracts/SystemContractsCaller.sol#L77) method of the `SystemContractsCaller` library should be used, so this library needs to be imported as well:
 
 ```solidity
-using TransactionHelper for Transaction;
+// to call non-view method of system contracts
+import "@matterlabs/zksync-contracts/l2/system-contracts/libraries/SystemContractsCaller.sol";
 ```
 
-Also, note that since the non-view methods of the `NONCE_HOLDER_SYSTEM_CONTRACT` are required to be called with the `isSystem` flag on, the [systemCall](https://github.com/matter-labs/v2-testnet-contracts/blob/main/l2/system-contracts/SystemContractsCaller.sol#L77) method of the `SystemContractsCaller` library should be used, so this library needs to be imported as well:
+
+The `TransactionHelper` library (already imported above with `using TransactionHelper for Transaction;`) can be used to get the hash of the transaction that should be signed. You can also implement your own signature scheme and use a different commitment for the transaction to sign, but in this example we use the hash provided by this library.
+
+Finally, the `_validateTransaction` method has to return the constant `ACCOUNT_VALIDATION_SUCCESS_MAGIC` if the validation is sucessful, or an empty value `bytes4(0)` if it fails.
+
+Here is the full implementation fo the `_validateTransaction` method:
 
 ```solidity
-import '@matterlabs/zksync-contracts/l2/system-contracts/SystemContractsCaller.sol';
-```
 
-Now we can implement the `_validateTransaction` method:
-
-```solidity
-function _validateTransaction(bytes32 _suggestedSignedHash, Transaction calldata _transaction) internal {
+function _validateTransaction(
+    bytes32 _suggestedSignedHash,
+    Transaction calldata _transaction
+) internal returns (bytes4 magic) {
     // Incrementing the nonce of the account.
     // Note, that reserved[0] by convention is currently equal to the nonce passed in the transaction
     SystemContractsCaller.systemCallWithPropagatedRevert(
         uint32(gasleft()),
         address(NONCE_HOLDER_SYSTEM_CONTRACT),
         0,
-        abi.encodeCall(INonceHolder.incrementMinNonceIfEquals, (_transaction.reserved[0]))
+        abi.encodeCall(INonceHolder.incrementMinNonceIfEquals, (_transaction.nonce))
     );
 
     bytes32 txHash;
     // While the suggested signed hash is usually provided, it is generally
     // not recommended to rely on it to be present, since in the future
     // there may be tx types with no suggested signed hash.
-    if(_suggestedSignedHash == bytes32(0)) {
+    if (_suggestedSignedHash == bytes32(0)) {
         txHash = _transaction.encodeHash();
     } else {
         txHash = _suggestedSignedHash;
     }
 
-    require(isValidSignature(txHash, _transaction.signature) == EIP1271_SUCCESS_RETURN_VALUE);
+    // The fact there is are enough balance for the account
+    // should be checked explicitly to prevent user paying for fee for a
+    // transaction that wouldn't be included on Ethereum.
+    uint256 totalRequiredBalance = _transaction.totalRequiredBalance();
+    require(totalRequiredBalance <= address(this).balance, "Not enough balance for fee + value");
+
+    if (isValidSignature(txHash, _transaction.signature) == EIP1271_SUCCESS_RETURN_VALUE) {
+        magic = ACCOUNT_VALIDATION_SUCCESS_MAGIC;
+    } else {
+        magic = bytes4(0);
+    }
 }
 ```
 
 ### Paying fees for the transaction
 
-We should now implement the `payForTransaction` method. The `TransactionHelper` library already provides us with the `payToTheBootloader` method, that sends `_transaction.maxFeePerErg * _transaction.gasLimit` ETH to the bootloader. So the implementation is rather straightforward:
+We should now implement the `payForTransaction` method. The `TransactionHelper` library already provides us with the `payToTheBootloader` method, that sends `_transaction.maxFeePerGas * _transaction.gasLimit` ETH to the bootloader. So the implementation is rather straightforward:
 
 ```solidity
-function payForTransaction(bytes32, bytes32, Transaction calldata _transaction) external payable override onlyBootloader {
-		bool success = _transaction.payToTheBootloader();
-		require(success, "Failed to pay the fee to the operator");
-}
+function payForTransaction(
+        bytes32,
+        bytes32,
+        Transaction calldata _transaction
+    ) external payable override onlyBootloader {
+        bool success = _transaction.payToTheBootloader();
+        require(success, "Failed to pay the fee to the operator");
+    }
 ```
 
-### Implementing `prePaymaster`
+### Implementing paymaster support
 
-While generally the account abstraction protocol enables performing arbitrary actions when interacting with the paymasters, there are some [common patterns](../developer-guides/aa.md#built-in-paymaster-flows) with the built-in support from EOAs.
-Unless you want to implement or restrict some specific paymaster use cases from your account, it is better to keep it consistent with EOAs. The `TransactionHelper` library provides the `processPaymasterInput` which does exactly that: processed the `prePaymaster` step the same as EOA does.
+While generally the account abstraction protocol enables performing arbitrary actions when interacting with the paymasters, there are some [common patterns](../developer-guides/aa.md#built-in-paymaster-flows) with the built-in support for EOAs.
+Unless you want to implement or restrict some specific paymaster use cases for your account, it is better to keep it consistent with EOAs. 
+
+The `TransactionHelper` library provides the `processPaymasterInput` which does exactly that: processes the paymaster parameters the same it's done in EOAs.
 
 ```solidity
-function prePaymaster(bytes32, bytes32, Transaction calldata _transaction) external payable override onlyBootloader {
-    _transaction.processPaymasterInput();
-}
+
+function prepareForPaymaster(
+        bytes32, // _txHash
+        bytes32, // _suggestedSignedHash
+        Transaction calldata _transaction
+    ) external payable override onlyBootloader {
+        _transaction.processPaymasterInput();
+    }
 ```
 
 ### Transaction execution
 
-The most basic implementation of the transaction execution is quite straightforward:
+The most basic implementation of the transaction execution is quite straightforward. We extract the transaction data and execute it:
 
 ```solidity
 function _executeTransaction(Transaction calldata _transaction) internal {
@@ -253,31 +411,30 @@ function _executeTransaction(Transaction calldata _transaction) internal {
     bytes memory data = _transaction.data;
 
     bool success;
+    // execute transaction
     assembly {
         success := call(gas(), to, value, add(data, 0x20), mload(data), 0, 0)
     }
 
-    // Needed for the transaction to be correctly processed by the server.
+    // Return value required for the transaction to be correctly processed by the server.
     require(success);
 }
 ```
 
-However, note that calling ContractDeployer is only possible with the `isSystem` call flag. In order to permit your users to deploy contracts, you should do so explicitly:
+However, note that calling ContractDeployer is only possible with the `isSystem` call flag. In order to allow your users to deploy contracts, you should do so explicitly:
 
 ```solidity
 function _executeTransaction(Transaction calldata _transaction) internal {
     address to = address(uint160(_transaction.to));
-    uint256 value = _transaction.reserved[1];
+    uint128 value = Utils.safeCastToU128(_transaction.value);
     bytes memory data = _transaction.data;
 
-    if(to == address(DEPLOYER_SYSTEM_CONTRACT)) {
-        // We allow calling ContractDeployer with any calldata
-        SystemContractsCaller.systemCallWithPropagatedRevert(
-            uint32(gasleft()),
-            to,
-            uint128(_transaction.reserved[1]), // By convention, reserved[1] is `value`
-            _transaction.data
-        );
+    if (to == address(DEPLOYER_SYSTEM_CONTRACT)) {
+        uint32 gas = Utils.safeCastToU32(gasleft());
+
+        // Note, that the deployer contract can only be called
+        // with a "systemCall" flag.
+        SystemContractsCaller.systemCallWithPropagatedRevert(gas, to, value, data);
     } else {
         bool success;
         assembly {
@@ -297,7 +454,7 @@ Note, that whether the operator will consider the transaction successful will de
 pragma solidity ^0.8.0;
 
 import "@matterlabs/zksync-contracts/l2/system-contracts/interfaces/IAccount.sol";
-import "@matterlabs/zksync-contracts/l2/system-contracts/TransactionHelper.sol";
+import "@matterlabs/zksync-contracts/l2/system-contracts/libraries/TransactionHelper.sol";
 
 import "@openzeppelin/contracts/interfaces/IERC1271.sol";
 
@@ -307,7 +464,7 @@ import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 // Access zkSync system contracts, in this case for nonce validation vs NONCE_HOLDER_SYSTEM_CONTRACT
 import "@matterlabs/zksync-contracts/l2/system-contracts/Constants.sol";
 // to call non-view method of system contracts
-import "@matterlabs/zksync-contracts/l2/system-contracts/SystemContractsCaller.sol";
+import "@matterlabs/zksync-contracts/l2/system-contracts/libraries/SystemContractsCaller.sol";
 
 contract TwoUserMultisig is IAccount, IERC1271 {
     // to get transaction hash
@@ -324,7 +481,7 @@ contract TwoUserMultisig is IAccount, IERC1271 {
             msg.sender == BOOTLOADER_FORMAL_ADDRESS,
             "Only bootloader can call this method"
         );
-        // Continue execution if called from the bootloader.
+        // Continure execution if called from the bootloader.
         _;
     }
 
@@ -337,24 +494,21 @@ contract TwoUserMultisig is IAccount, IERC1271 {
         bytes32,
         bytes32 _suggestedSignedHash,
         Transaction calldata _transaction
-    ) external payable override onlyBootloader {
-        _validateTransaction(_suggestedSignedHash, _transaction);
+    ) external payable override onlyBootloader returns (bytes4 magic) {
+        return _validateTransaction(_suggestedSignedHash, _transaction);
     }
 
     function _validateTransaction(
         bytes32 _suggestedSignedHash,
         Transaction calldata _transaction
-    ) internal {
+    ) internal returns (bytes4 magic) {
         // Incrementing the nonce of the account.
         // Note, that reserved[0] by convention is currently equal to the nonce passed in the transaction
         SystemContractsCaller.systemCallWithPropagatedRevert(
             uint32(gasleft()),
             address(NONCE_HOLDER_SYSTEM_CONTRACT),
             0,
-            abi.encodeCall(
-                INonceHolder.incrementMinNonceIfEquals,
-                (_transaction.reserved[0])
-            )
+            abi.encodeCall(INonceHolder.incrementMinNonceIfEquals, (_transaction.nonce))
         );
 
         bytes32 txHash;
@@ -367,10 +521,17 @@ contract TwoUserMultisig is IAccount, IERC1271 {
             txHash = _suggestedSignedHash;
         }
 
-        require(
-            isValidSignature(txHash, _transaction.signature) ==
-                EIP1271_SUCCESS_RETURN_VALUE
-        );
+        // The fact there is are enough balance for the account
+        // should be checked explicitly to prevent user paying for fee for a
+        // transaction that wouldn't be included on Ethereum.
+        uint256 totalRequiredBalance = _transaction.totalRequiredBalance();
+        require(totalRequiredBalance <= address(this).balance, "Not enough balance for fee + value");
+
+        if (isValidSignature(txHash, _transaction.signature) == EIP1271_SUCCESS_RETURN_VALUE) {
+            magic = ACCOUNT_VALIDATION_SUCCESS_MAGIC;
+        } else {
+            magic = bytes4(0);
+        }
     }
 
     function executeTransaction(
@@ -383,29 +544,19 @@ contract TwoUserMultisig is IAccount, IERC1271 {
 
     function _executeTransaction(Transaction calldata _transaction) internal {
         address to = address(uint160(_transaction.to));
-        uint256 value = _transaction.reserved[1];
+        uint128 value = Utils.safeCastToU128(_transaction.value);
         bytes memory data = _transaction.data;
 
         if (to == address(DEPLOYER_SYSTEM_CONTRACT)) {
-            // We allow calling ContractDeployer with any calldata
-            SystemContractsCaller.systemCallWithPropagatedRevert(
-                uint32(gasleft()),
-                to,
-                uint128(_transaction.reserved[1]), // By convention, reserved[1] is `value`
-                _transaction.data
-            );
+            uint32 gas = Utils.safeCastToU32(gasleft());
+
+            // Note, that the deployer contract can only be called
+            // with a "systemCall" flag.
+            SystemContractsCaller.systemCallWithPropagatedRevert(gas, to, value, data);
         } else {
             bool success;
             assembly {
-                success := call(
-                    gas(),
-                    to,
-                    value,
-                    add(data, 0x20),
-                    mload(data),
-                    0,
-                    0
-                )
+                success := call(gas(), to, value, add(data, 0x20), mload(data), 0, 0)
             }
             require(success);
         }
@@ -416,27 +567,109 @@ contract TwoUserMultisig is IAccount, IERC1271 {
         payable
     {
         _validateTransaction(bytes32(0), _transaction);
-
         _executeTransaction(_transaction);
     }
 
-    function isValidSignature(bytes32 _hash, bytes calldata _signature)
+    function isValidSignature(bytes32 _hash, bytes memory _signature)
         public
         view
         override
-        returns (bytes4)
+        returns (bytes4 magic)
     {
-        // The signature is the concatenation of the ECDSA signatures of the owners
-        // Each ECDSA signature is 65 bytes long. That means that the combined signature is 130 bytes long.
-        require(_signature.length == 130, "Signature length is incorrect");
+        magic = EIP1271_SUCCESS_RETURN_VALUE;
 
-        address recoveredAddr1 = ECDSA.recover(_hash, _signature[0:65]);
-        address recoveredAddr2 = ECDSA.recover(_hash, _signature[65:130]);
+        if (_signature.length != 130) {
+            // Signature is invalid anyway, but we need to proceed with the signature verification as usual
+            // in order for the fee estimation to work correctly
+            _signature = new bytes(130);
+            
+            // Making sure that the signatures look like a valid ECDSA signature and are not rejected rightaway
+            // while skipping the main verification process.
+            _signature[64] = bytes1(uint8(27));
+            _signature[129] = bytes1(uint8(27));
+        }
 
-        require(recoveredAddr1 == owner1);
-        require(recoveredAddr2 == owner2);
+        (bytes memory signature1, bytes memory signature2) = extractECDSASignature(_signature);
 
-        return EIP1271_SUCCESS_RETURN_VALUE;
+        if(!checkValidECDSASignatureFormat(signature1) || !checkValidECDSASignatureFormat(signature2)) {
+            magic = bytes4(0);
+        }
+
+        address recoveredAddr1 = ECDSA.recover(_hash, signature1);
+        address recoveredAddr2 = ECDSA.recover(_hash, signature2);
+
+        // Note, that we should abstain from using the require here in order to allow for fee estimation to work
+        if(recoveredAddr1 != owner1 || recoveredAddr2 != owner2) {
+            magic = bytes4(0);
+        }
+    }
+
+    // This function verifies that the ECDSA signature is both in correct format and non-malleable
+    function checkValidECDSASignatureFormat(bytes memory _signature) internal pure returns (bool) {
+        if(_signature.length != 65) {
+            return false;
+        }
+
+        uint8 v;
+		bytes32 r;
+		bytes32 s;
+		// Signature loading code
+		// we jump 32 (0x20) as the first slot of bytes contains the length
+		// we jump 65 (0x41) per signature
+		// for v we load 32 bytes ending with v (the first 31 come from s) then apply a mask
+		assembly {
+			r := mload(add(_signature, 0x20))
+			s := mload(add(_signature, 0x40))
+			v := and(mload(add(_signature, 0x41)), 0xff)
+		}
+		if(v != 27 && v != 28) {
+            return false;
+        }
+
+		// EIP-2 still allows signature malleability for ecrecover(). Remove this possibility and make the signature
+        // unique. Appendix F in the Ethereum Yellow paper (https://ethereum.github.io/yellowpaper/paper.pdf), defines
+        // the valid range for s in (301): 0 < s < secp256k1n ÷ 2 + 1, and for v in (302): v ∈ {27, 28}. Most
+        // signatures from current libraries generate a unique signature with an s-value in the lower half order.
+        //
+        // If your library generates malleable signatures, such as s-values in the upper range, calculate a new s-value
+        // with 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141 - s1 and flip v from 27 to 28 or
+        // vice versa. If your library also generates signatures with 0/1 for v instead 27/28, add 27 to v to accept
+        // these malleable signatures as well.
+        if(uint256(s) > 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0) {
+            return false;
+        }
+
+        return true;
+    }
+    
+    function extractECDSASignature(bytes memory _fullSignature) internal pure returns (bytes memory signature1, bytes memory signature2) {
+        require(_fullSignature.length == 130, "Invalid length");
+
+        signature1 = new bytes(65);
+        signature2 = new bytes(65);
+
+        // Copying the first signature. Note, that we need an offset of 0x20 
+        // since it is where the length of the `_fullSignature` is stored
+        assembly {
+            let r := mload(add(_fullSignature, 0x20))
+			let s := mload(add(_fullSignature, 0x40))
+			let v := and(mload(add(_fullSignature, 0x41)), 0xff)
+
+            mstore(add(signature1, 0x20), r)
+            mstore(add(signature1, 0x40), s)
+            mstore8(add(signature1, 0x60), v)
+        }
+
+        // Copying the second signature.
+        assembly {
+            let r := mload(add(_fullSignature, 0x61))
+            let s := mload(add(_fullSignature, 0x81))
+            let v := and(mload(add(_fullSignature, 0x82)), 0xff)
+
+            mstore(add(signature2, 0x20), r)
+            mstore(add(signature2, 0x40), s)
+            mstore8(add(signature2, 0x60), v)
+        }
     }
 
     function payForTransaction(
@@ -448,28 +681,32 @@ contract TwoUserMultisig is IAccount, IERC1271 {
         require(success, "Failed to pay the fee to the operator");
     }
 
-    function prePaymaster(
-        bytes32,
-        bytes32,
+    function prepareForPaymaster(
+        bytes32, // _txHash
+        bytes32, // _suggestedSignedHash
         Transaction calldata _transaction
     ) external payable override onlyBootloader {
         _transaction.processPaymasterInput();
     }
 
-    receive() external payable {
-        // If the bootloader called the `receive` function, it likely means
-        // that something went wrong and the transaction should be aborted. The bootloader should
-        // only interact through the `validateTransaction`/`executeTransaction` methods.
+    fallback() external {
+        // fallback of default account shouldn't be called by bootloader under no circumstances
         assert(msg.sender != BOOTLOADER_FORMAL_ADDRESS);
+
+        // If the contract is called directly, behave like an EOA
+    }
+
+    receive() external payable {
+        // If the contract is called directly, behave like an EOA.
+        // Note, that is okay if the bootloader sends funds with no calldata as it may be used for refunds/operator payments
     }
 }
-
 
 ```
 
 ## The factory
 
-Now, let's build a factory that can deploy these accounts. Note, that if we want to deploy AA, we need to interact directly with the `DEPLOYER_SYSTEM_CONTRACT`. For deterministic addresses, we will use `create2Account` method.
+Now, let's build a factory that can deploy these accounts. To deploy the smat contract account, we need to interact directly with the `DEPLOYER_SYSTEM_CONTRACT`. For deterministic addresses, we will call the `create2Account` method.
 
 The code will look the following way:
 
@@ -478,7 +715,7 @@ The code will look the following way:
 pragma solidity ^0.8.0;
 
 import "@matterlabs/zksync-contracts/l2/system-contracts/Constants.sol";
-import "@matterlabs/zksync-contracts/l2/system-contracts/SystemContractsCaller.sol";
+import "@matterlabs/zksync-contracts/l2/system-contracts/libraries/SystemContractsCaller.sol";
 
 contract AAFactory {
     bytes32 public aaBytecodeHash;
@@ -499,18 +736,18 @@ contract AAFactory {
                 uint128(0),
                 abi.encodeCall(
                     DEPLOYER_SYSTEM_CONTRACT.create2Account,
-                    (salt, aaBytecodeHash, abi.encode(owner1, owner2))
+                    (salt, aaBytecodeHash, abi.encode(owner1, owner2), IContractDeployer.AccountAbstractionVersion.Version1)
                 )
             );
         require(success, "Deployment failed");
 
-        (accountAddress, ) = abi.decode(returnData, (address, bytes));
+        (accountAddress) = abi.decode(returnData, (address));
     }
 }
 
 ```
 
-Note, that on zkSync, the deployment is not done via bytecode, but via bytecode hash. The bytecode itself is passed to the operator via `factoryDeps` field. Note, that the `_aaBytecodeHash` must be formed specially:
+It's worth remembering that on zkSync, contract deployments are not done via bytecode, but via bytecode hash. The bytecode itself is passed to the operator via `factoryDeps` field. Note, that the `_aaBytecodeHash` must be formed specially:
 
 - Firstly, it is hashed with sha256.
 - Then, the first two bytes are replaced with the length of the bytecode in 32-byte words.


### PR DESCRIPTION
Adds information about contracts using `SystemContractsCaller`, which requires compilation with `isSystem` flag.
Adds info about flattening contracts in Changelog
Updates AA tutorial