### PR TITLE
Remove version from zksync-web3 which allows for latest version

### DIFF
--- a/docs/dev/building-on-zksync/hello-world.md
+++ b/docs/dev/building-on-zksync/hello-world.md
@@ -34,11 +34,11 @@ cd greeter-example
 
 # For Yarn
 yarn init -y
-yarn add -D typescript ts-node ethers@^5.7.2 zksync-web3@^0.13.1 hardhat @matterlabs/hardhat-zksync-solc @matterlabs/hardhat-zksync-deploy
+yarn add -D typescript ts-node ethers@^5.7.2 zksync-web3 hardhat @matterlabs/hardhat-zksync-solc @matterlabs/hardhat-zksync-deploy
 
 # For NPM
 npm init -y
-npm i -D typescript ts-node ethers@^5.7.2 zksync-web3@^0.13.1 hardhat @matterlabs/hardhat-zksync-solc @matterlabs/hardhat-zksync-deploy
+npm i -D typescript ts-node ethers@^5.7.2 zksync-web3 hardhat @matterlabs/hardhat-zksync-solc @matterlabs/hardhat-zksync-deploy
 ```
 
 Please note that Typescript is required by zkSync plugins.


### PR DESCRIPTION
Removes version from zksync-web3 to prevent some issues we've seen in Discord at least once of someone locking to an earlier version.