### PR TITLE
hardhat updates zksolc 0.4.0

### DIFF
--- a/docs/dev/building-on-zksync/hello-world.md
+++ b/docs/dev/building-on-zksync/hello-world.md
@@ -54,8 +54,7 @@ import "@matterlabs/hardhat-zksync-verify";
 
 module.exports = {
   zksolc: {
-    version: "1.3.10",
-    compilerSource: "binary",
+    version: "latest", // Uses latest available in https://github.com/matter-labs/zksolc-bin/
     settings: {},
   },
   defaultNetwork: "zkSyncTestnet",

--- a/docs/dev/tutorials/aa-daily-spend-limit.md
+++ b/docs/dev/tutorials/aa-daily-spend-limit.md
@@ -53,8 +53,7 @@ import "@matterlabs/hardhat-zksync-solc";
 
 const config: HardhatUserConfig = {
     zksolc: {
-        version: "1.3.10",
-        compilerSource: "binary",
+        version: "latest", // Uses latest available in https://github.com/matter-labs/zksolc-bin/
         settings: { 
             isSystem: true,
         },

--- a/docs/dev/tutorials/cross-chain-tutorial.md
+++ b/docs/dev/tutorials/cross-chain-tutorial.md
@@ -242,8 +242,7 @@ import "@matterlabs/hardhat-zksync-solc";
 
 module.exports = {
   zksolc: {
-    version: "1.3.10",
-    compilerSource: "binary",
+    version: "latest",
   },
   defaultNetwork: "zkSyncTestnet",
 

--- a/docs/dev/tutorials/custom-aa-tutorial.md
+++ b/docs/dev/tutorials/custom-aa-tutorial.md
@@ -56,11 +56,10 @@ import "@matterlabs/hardhat-zksync-solc";
 
 const config: HardhatUserConfig = {
   zksolc: {
-    version: "1.3.10", // Use latest available in https://github.com/matter-labs/zksolc-bin/
-    compilerSource: "binary",
-      settings: {
-        isSystem: true,
-      },
+    version: "latest", // Uses latest available in https://github.com/matter-labs/zksolc-bin/
+    settings: {
+      isSystem: true,
+    },
   },
   defaultNetwork: "zkSyncTestnet",
 

--- a/docs/dev/tutorials/custom-paymaster-tutorial.md
+++ b/docs/dev/tutorials/custom-paymaster-tutorial.md
@@ -64,8 +64,7 @@ import "@matterlabs/hardhat-zksync-solc";
 
 const config: HardhatUserConfig = {
   zksolc: {
-    version: "1.3.10", // Use latest available in https://github.com/matter-labs/zksolc-bin/
-    compilerSource: "binary",
+    version: "latest", // Uses latest available in https://github.com/matter-labs/zksolc-bin/
     settings: {},
   },
   defaultNetwork: "zkSyncTestnet",

--- a/docs/reference/architecture/contracts/contract-development.md
+++ b/docs/reference/architecture/contracts/contract-development.md
@@ -16,7 +16,7 @@ Please read [this section of the docs](../../../tools/compiler-toolchain/solidit
 
 ## Vyper support
 
-Currently only Vyper 0.3.3 and 0.3.8 versions are supported. Versions 0.3.4 to 0.3.7 are not supported.
+Currently only Vyper 0.3.3 and 0.3.9 versions are supported. Versions 0.3.4 to 0.3.8 (both included) are not supported.
 
 ## Compilers
 

--- a/docs/reference/architecture/contracts/contract-development.md
+++ b/docs/reference/architecture/contracts/contract-development.md
@@ -16,7 +16,7 @@ Please read [this section of the docs](../../../tools/compiler-toolchain/solidit
 
 ## Vyper support
 
-Currently only Vyper `0.3.3` is supported.
+Currently only Vyper v0.3.3 and v0.3.8 versions are supported. 
 
 ## Compilers
 

--- a/docs/reference/architecture/contracts/contract-development.md
+++ b/docs/reference/architecture/contracts/contract-development.md
@@ -16,7 +16,7 @@ Please read [this section of the docs](../../../tools/compiler-toolchain/solidit
 
 ## Vyper support
 
-Currently only Vyper v0.3.3 and v0.3.8 versions are supported. 
+Currently only Vyper 0.3.3 and 0.3.8 versions are supported. Versions 0.3.4 to 0.3.7 are not supported.
 
 ## Compilers
 

--- a/docs/tools/compiler-toolchain/vyper.md
+++ b/docs/tools/compiler-toolchain/vyper.md
@@ -37,4 +37,4 @@ Other output formats are available via the `-f` option. Check out `vyper --help`
 
 ## Limitations
 
-Currently only Vyper 0.3.3 and 0.3.8 versions are supported. Versions 0.3.4 to 0.3.7 are not supported.
+Currently only Vyper 0.3.3 and 0.3.9 versions are supported. Versions 0.3.4 to 0.3.8 (both included) are not supported.

--- a/docs/tools/compiler-toolchain/vyper.md
+++ b/docs/tools/compiler-toolchain/vyper.md
@@ -37,4 +37,4 @@ Other output formats are available via the `-f` option. Check out `vyper --help`
 
 ## Limitations
 
-Currently only Vyper v0.3.3 is supported.
+Currently only Vyper v0.3.3 and v0.3.8 versions are supported. 

--- a/docs/tools/compiler-toolchain/vyper.md
+++ b/docs/tools/compiler-toolchain/vyper.md
@@ -37,4 +37,4 @@ Other output formats are available via the `-f` option. Check out `vyper --help`
 
 ## Limitations
 
-Currently only Vyper v0.3.3 and v0.3.8 versions are supported. 
+Currently only Vyper 0.3.3 and 0.3.8 versions are supported. Versions 0.3.4 to 0.3.7 are not supported.

--- a/docs/tools/hardhat/compiling-libraries.md
+++ b/docs/tools/hardhat/compiling-libraries.md
@@ -63,8 +63,7 @@ import "@matterlabs/hardhat-zksync-solc";
 
 module.exports = {
   zksolc: {
-    version: "1.3.10",
-    compilerSource: "binary",
+    version: "latest", // Uses latest available in https://github.com/matter-labs/zksolc-bin/
     settings: {
       libraries: {
         "contracts/MiniMath.sol": {

--- a/docs/tools/hardhat/getting-started.md
+++ b/docs/tools/hardhat/getting-started.md
@@ -80,12 +80,11 @@ const zkSyncTestnet =
 This template project includes a basic unit test in the `/test` folder that runs with the local-setup and can be executed with `yarn test`. Learn more about how to [start the local setup and write unit tests here](./testing.md).
 :::
 
-The `zksolc` block contains the minimal configuration required for the compiler.
+The `zksolc` block contains the minimal configuration for the compiler.
 
 ```typescript
 zksolc: {
-  version: "1.3.10",
-  compilerSource: "binary",
+  version: "latest", // Uses latest available in https://github.com/matter-labs/zksolc-bin/
   settings: {},
 },
 ```

--- a/docs/tools/hardhat/hardhat-zksync-solc.md
+++ b/docs/tools/hardhat/hardhat-zksync-solc.md
@@ -45,7 +45,6 @@ Any configuration parameters should be added inside a `zksolc` property in the `
 ```typescript
 zksolc: {
     version: "latest", // optional.
-    compilerSource: "binary",  // optional.
     settings: {
       compilerPath: "zksolc",  // optional. Ignored for compilerSource "docker". Can be used if compiler is located in a specific folder
       libraries:{}, // optional. References to non-inlinable libraries

--- a/docs/tools/hardhat/hardhat-zksync-solc.md
+++ b/docs/tools/hardhat/hardhat-zksync-solc.md
@@ -2,7 +2,7 @@
 
 This plugin is used to provide a convenient interface for compiling Solidity smart contracts before deploying them to zkSync Era.
 
-[Changelog](https://github.com/matter-labs/hardhat-zksync/blob/main/packages/hardhat-zksync-solc/CHANGELOG.md)
+Learn more about the latest updates in the [changelog](https://github.com/matter-labs/hardhat-zksync/blob/main/packages/hardhat-zksync-solc/CHANGELOG.md)
 
 ## Installation
 
@@ -25,63 +25,54 @@ npm i -D @matterlabs/hardhat-zksync-solc
 ```
 :::
 
-### Exports
 
-This plugin most often will not be used directly in the code.
+## Configuration
 
-### Configuration
+Import the package in the `hardhat.config.ts` file:
 
-This plugin is configured in the `hardhat.config.ts` file of your project. Here is an example
+```ts
+import "@matterlabs/hardhat-zksync-solc";
+```
+
+::: info Default config in hardhat-zksync-solc ^0.4.0
+
+Version 0.4.0 introduced a default configuration making all parameters optional. You can override the default configuration in the `hardhat.config.ts` file.
+
+:::
+
+Any configuration parameters should be added inside a `zksolc` property in the `hardhat.config.ts` file:
 
 ```typescript
-import "@matterlabs/hardhat-zksync-solc";
-
-module.exports = {
-  zksolc: {
-      version: "1.3.10",
-      compilerSource: "binary",
-      settings: {
-        //compilerPath: "zksolc",  // optional. Ignored for compilerSource "docker". Can be used if compiler is located in a specific folder
-        libraries:{}, // optional. References to non-inlinable libraries
-        isSystem: false, // optional.  Enables Yul instructions available only for zkSync system contracts and libraries
-        forceEvmla: false, // optional. Falls back to EVM legacy assembly if there is a bug with Yul
-        optimizer: {
-          enabled: true, // optional. True by default
-          mode: '3' // optional. 3 by default, z to optimize bytecode size
-        } 
-      }
-  },
-  defaultNetwork: "zkTestnet",
-  networks: {
-    goerli: {
-      url: "https://goerli.infura.io/v3/<API_KEY>", // The Ethereum Web3 RPC URL (optional).
-      zksync: false, // Set to false to target other networks.
-    },
-    zkTestnet: {
-      url: "https://testnet.era.zksync.dev", // The testnet RPC URL of zkSync Era network.
-      ethNetwork: "goerli", // The Ethereum Web3 RPC URL, or the identifier of the network (e.g. `mainnet` or `goerli`)
-    zksync: true,
+zksolc: {
+    version: "latest", // optional.
+    compilerSource: "binary",  // optional.
+    settings: {
+      compilerPath: "zksolc",  // optional. Ignored for compilerSource "docker". Can be used if compiler is located in a specific folder
+      libraries:{}, // optional. References to non-inlinable libraries
+      isSystem: false, // optional.  Enables Yul instructions available only for zkSync system contracts and libraries
+      forceEvmla: false, // optional. Falls back to EVM legacy assembly if there is a bug with Yul
+      optimizer: {
+        enabled: true, // optional. True by default
+        mode: '3' // optional. 3 by default, z to optimize bytecode size
+      },
+      experimental: {
+        dockerImage: '', // deprecated
+        tag: ''   // deprecated
+      },
     }
-  },
-  // defaultNetwork: "zkTestnet", // optional (if not set, use '--network zkTestnet')
-  solidity: {
-      version: "0.8.13",
-  },
-}
+},
 
 ```
 
 ::: warning
 
 - Compilers are no longer released as Docker images and its usage is no longer recommended. 
-- Use the `compilerSource: "binary"` in the `hardhat.config.ts` file to use the binary instead.
 
 :::
 
 - `version` is the `zksolc` compiler version. Compiler versions can be found in [the following repository](https://github.com/matter-labs/zksolc-bin).
-- `compilerSource` indicates the compiler source and can be either `docker` or `binary` (recommended). If there isn't a compiler binary already installed, the plugin will automatically download it. If `docker` is used, you'd need to run Docker desktop in the background and provide both `dockerImage` and `tag` in the experimental section.
-- `compilerPath` (optional) is a field with the path to the `zksolc` binary. By default, the binary in `$PATH` is used. If `compilerSource` is `docker`, this field is ignored.
-- `dockerImage` and `tag` make up the name of the compiler docker image. If `compilerSource` is `binary`, these fields are ignored.
+- `compilerSource` indicates the compiler source and can be either `binary` (default) or `docker` (deprecated). If there isn't a compiler binary already installed, the plugin will automatically download it. 
+- `compilerPath` (optional) is a field with the path to the `zksolc` binary. By default, the binary in `$PATH` is used. 
 - `libraries` if your contract uses non-inlinable libraries as dependencies, they have to be defined here. Learn more about [compiling libraries here](./compiling-libraries.md)
 - `isSystem` - required if contracts use enables Yul instructions available only for zkSync system contracts and libraries
 - `forceEvmla` - falls back to EVM legacy assembly if there is an issue with the Yul IR compilation pipeline.
@@ -90,7 +81,7 @@ module.exports = {
   - `mode`: `3` (default) recommended for most projects. Mode `z` reduces bytecode size for large projects that make heavy use of `keccak` and far calls.
 - `metadata`: Metadata settings. If the option is omitted, the metadata hash appends by default:
   - `bytecodeHash`: Can only be `none`. It removes metadata hash from the bytecode.
-- `zksync` network option indicates whether zksolc is enabled on a certain network. `false` by default. Useful for multichain projects in which you can enable `zksync` only for specific networks.
+- `dockerImage` and `tag` are deprecated options used to identify the name of the compiler docker image.
 
 
 ::: warning `forceEvmla` usage
@@ -105,13 +96,57 @@ For Solidity versions older than 0.8, only this compilation mode is available an
 
 :::
 
-### Commands
+### Network configuration
 
-`yarn hardhat compile` -- compiles all the smart contracts in the `contracts` directory and creates the `artifacts-zk` folder with all the compilation artifacts, including factory dependencies for the contracts, which could be used for contract deployment.
+Configure the `zksync` parameter in the networks to enable the zksolc compiler:
+
+```ts
+defaultNetwork: "zkSyncTestnet",
+networks: {
+  goerli: {
+    url: "https://goerli.infura.io/v3/<API_KEY>", // The Ethereum Web3 RPC URL (optional).
+    zksync: false, // disables zksolc compiler
+  },
+  zkSyncTestnet: {
+    url: "https://testnet.era.zksync.dev", // The testnet RPC URL of zkSync Era network.
+    ethNetwork: "goerli", // The Ethereum Web3 RPC URL, or the identifier of the network (e.g. `mainnet` or `goerli`)
+    zksync: true, // enables zksolc compiler
+  }
+},
+```
+
+- `zksync` network option indicates whether zksolc is enabled on a certain network. `false` by default. Useful for multichain projects in which you can enable `zksync` only for specific networks.
+
+## Commands
+
+
+::: code-tabs
+
+@tab:active yarn
+
+```bash
+yarn hardhat compile
+```
+
+@tab npm
+
+```bash
+npx hardhat compile
+```
+:::
+
+
+Compiles all the smart contracts in the `contracts` directory and creates the `artifacts-zk` folder with all the compilation artifacts, including factory dependencies for the contracts, which could be used for contract deployment.
 
 To understand what the factory dependencies are, read more about them in the [Web3 API](../../api/api.md) documentation.
 
-## Why is there an `unexpected end of JSON input` compilation error?
+## Troubleshoting
+
+#### Error in plugin @matterlabs/hardhat-zksync-solc: Invalid zksolc compiler version
+
+This error is returned when the version defined in the `hardhat.config.ts` file is lower than the minimal required (versions are defined [here](https://github.com/matter-labs/zksolc-bin/blob/main/version.json)). Update the version to solve the issue.
+
+#### Why is there an `unexpected end of JSON input` compilation error?
 
 This is an error that is usually thrown when compiling a large smart contract codebase.
 

--- a/docs/tools/hardhat/hardhat-zksync-vyper.md
+++ b/docs/tools/hardhat/hardhat-zksync-vyper.md
@@ -2,6 +2,8 @@
 
 The [@matterlabs/hardhat-zksync-vyper](https://www.npmjs.com/package/@matterlabs/hardhat-zksync-vyper) plugin provides an interface for compiling Vyper smart contracts before deploying them to zkSync Era.
 
+Learn more about the latest updates in the [changelog](https://github.com/matter-labs/hardhat-zksync/blob/main/packages/hardhat-zksync-vyper/CHANGELOG.md).
+
 ## Set up
 
 ### 1. Scaffold a new project
@@ -39,7 +41,7 @@ import "@matterlabs/hardhat-zksync-deploy";
 
 const config: HardhatUserConfig = {
   zkvyper: {
-    version: "1.3.7",
+    version: "latest",
     compilerSource: "binary", // docker usage no longer recommended
     settings: {
       // compilerPath: "zkvyper", // optional field with the path to the `zkvyper` binary.
@@ -66,18 +68,20 @@ const config: HardhatUserConfig = {
 export default config;
 ```
 
-#### Options
+#### Configuration
 
-- `version`: The `zkvyper` compiler version. Find the latest compiler versions in the [zkvyper repo](https://github.com/matter-labs/zkvyper-bin).
-- `compilerSource`: Indicates the compiler source and can be either `binary`. (A `docker` option is no longer recommended). If there is no previous installation, the plugin automatically downloads one. 
+::: info zero-config
 
-:::warning
-The `docker` option is not recommended as compilers are no longer released as Docker images.
+`hardhat-zksync-vyper` v0.2.0 introduced a default configuration so all  parameters are optional.
+
 :::
 
+Any configuration parameters should be added inside a `zkvyper` property in the `hardhat.config.ts` file:
+
+- `version`: The `zkvyper` compiler version. Default value is `latest`. Find the latest compiler versions in the [zkvyper repo](https://github.com/matter-labs/zkvyper-bin).
+- `compilerSource`: Indicates the compiler source and can be either `binary`. (A `docker` option is no longer recommended). If there is no previous installation, the plugin automatically downloads one. 
 - `compilerPath`: Optional field with the path to the `zkvyper` binary. By default, the binary in `$PATH` is used.
 - `libraries`: Define any non-inlinable libraries your contracts use as dependencies here. Learn more about [compiling libraries](./compiling-libraries.md).
-- `zksync`: Indicates whether `zkvyper` is enabled on zkSync Era. This option is useful for multichain projects in which you want to enable `zksync` for specific networks only.
 
 ### 4. Create Vyper contract
 

--- a/docs/tools/hardhat/hardhat-zksync-vyper.md
+++ b/docs/tools/hardhat/hardhat-zksync-vyper.md
@@ -42,7 +42,6 @@ import "@matterlabs/hardhat-zksync-deploy";
 const config: HardhatUserConfig = {
   zkvyper: {
     version: "latest",
-    compilerSource: "binary", // docker usage no longer recommended
     settings: {
       // compilerPath: "zkvyper", // optional field with the path to the `zkvyper` binary.
       libraries: {}, // optional. References to non-inlinable libraries

--- a/docs/tools/hardhat/hardhat-zksync-vyper.md
+++ b/docs/tools/hardhat/hardhat-zksync-vyper.md
@@ -57,7 +57,7 @@ const config: HardhatUserConfig = {
       zksync: true,
     },
   },
-  // Currently, only Vyper ^0.3.3 is supported.
+  // Currently only Vyper v0.3.3 and v0.3.8 versions are supported. 
   vyper: {
     version: "0.3.3",
   },

--- a/docs/tools/hardhat/hardhat-zksync-vyper.md
+++ b/docs/tools/hardhat/hardhat-zksync-vyper.md
@@ -59,7 +59,7 @@ const config: HardhatUserConfig = {
       zksync: true,
     },
   },
-  // Currently only Vyper v0.3.3 and v0.3.8 versions are supported. 
+  // Currently only Vyper v0.3.3 and v0.3.9 versions are supported. 
   vyper: {
     version: "0.3.3",
   },

--- a/docs/tools/hardhat/migrating-to-zksync.md
+++ b/docs/tools/hardhat/migrating-to-zksync.md
@@ -67,8 +67,7 @@ Finally, add the compiler options inside a `zksolc` or `zkvyper` property. Here 
 
 ```typescript
 zksolc: {
-  version: "1.3.10",
-  compilerSource: "binary",
+  version: "latest",
   settings: {},
 },
 ```
@@ -110,8 +109,7 @@ import "@matterlabs/hardhat-zksync-solc";
 
 const config: HardhatUserConfig = {
   zksolc: {
-    version: "1.3.10",
-    compilerSource: "binary",
+    version: "latest", // Uses latest available in https://github.com/matter-labs/zksolc-bin/
     settings: {},
   },
   defaultNetwork: "zkSyncTestnet",

--- a/docs/tools/hardhat/testing.md
+++ b/docs/tools/hardhat/testing.md
@@ -148,8 +148,8 @@ const zkSyncTestnet =
 
 module.exports = {
   zksolc: {
-    version: "1.3.10",
-    compilerSource: "binary",
+    version: "latest", // Uses latest available in https://github.com/matter-labs/zksolc-bin/
+
     settings: {},
   },
   // defaults to zkSync network

--- a/docs/tools/zksync-cli/README.md
+++ b/docs/tools/zksync-cli/README.md
@@ -28,4 +28,4 @@ More commands will be added shortly but if you have any suggestions, feel free t
 
 ## Troubleshooting
 
-If you find any issues, you can [open an issue on GitHub](https://github.com/matter-labs/zksync-cli/issues/new) or report it to us [in our Discord](https://join.zksync.dev/).
+If you find any issues, you can [open an issue on GitHub](https://github.com/matter-labs/zksync-cli/issues/new) or report it to us [in GitHub discussions](https://github.com/zkSync-Community-Hub/zkync-developers/discussions).


### PR DESCRIPTION
- updates in hardhat-zksync-solc related to v0.4.0
- updates mentions to supported vyper versions
- updates all compiler versions to `latest` across all pages