### PR TITLE
fix: add context on when to use createAddress and create2Address

### DIFF
--- a/docs/build/tutorials/smart-contract-development/account-abstraction/custom-aa-tutorial.md
+++ b/docs/build/tutorials/smart-contract-development/account-abstraction/custom-aa-tutorial.md
@@ -944,8 +944,8 @@ export default async function (hre: HardhatRuntimeEnvironment) {
 :::tip
 
 - zkSync has different address derivation rules from Ethereum.
-- Always use the [`createAddress`](../../../sdks/js/utils.md#createaddress) and [`create2Address`](../../../sdks/js/utils.md#create2address) utility functions of the `zksync-ethers` SDK.
-- Read the documentation for more information on [address derivation differences between Ethereum and zkSync](../../../developer-reference/differences-with-ethereum.md).
+- Always use the [`createAddress`](../../../sdks/js/utils.md#createaddress) and [`create2Address`](../../../sdks/js/utils.md#create2address) utility functions of the `zksync-ethers` SDK when looking to determine a contract's address.
+- Read the documentation for more information on [address derivation differences between Ethereum and zkSync](<[../../../developer-reference/differences-with-ethereum.md](https://docs.zksync.io/build/developer-reference/differences-with-ethereum.html#create-create2)>).
   :::
 
 ### Start a Transaction from the Account


### PR DESCRIPTION
# What :computer: 
- added context to working with createaddress and create2address. 
- updated a link pointing to the differences between `createAddress` and `create2Address` and address creation in general in the EVM

# Why :hand:
Added context to when to use `create2Address`
