### PR TITLE
docs(footer): Fix Mainnet Link Redirecting to Sepolia

### DIFF
--- a/docs/.vuepress/theme.ts
+++ b/docs/.vuepress/theme.ts
@@ -41,7 +41,7 @@ export default hopeTheme({
       </div>
       <div class="footer-links">
         <a href="https://github.com/zksync/credo" target="_blank">ZK Credo</a>
-        <a href="https://sepolia.explorer.zksync.io/" target="_blank">Block explorer</a>
+        <a href="https://explorer.zksync.io/" target="_blank">Block explorer</a>
         <a href="https://zksync.io/explore#bridges" target="_blank">Bridges & Wallets</a>
         <a href="https://github.com/zkSync-Community-Hub/zkync-developers/discussions" target="_blank">GitHub Discussions</a>
         <a href="https://ecosystem.zksync.io/" target="_blank">Ecosystem</a>


### PR DESCRIPTION
# What :computer: 
* The link in the documentation footer labeled "[Block Explorer]" (which should redirect to the Mainnet) was incorrectly pointing to Sepolia

# Why :hand:
* Era isn't in testnet anymore so I think the links should be updated to mainnet

# Evidence :camera:
![image](https://github.com/matter-labs/zksync-web-era-docs/assets/39260099/19a231f9-8895-46d5-b7d0-800c2ec82717)


<!-- All sections below are optional. You can erase any section not applicable to your Pull Request. -->
